### PR TITLE
chore: #12 v0.1.0 publish 準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] - 2026-05-22
 
 ### Added
 
+- **Phase 3 visual field & light filters** (#5, #6): `glaucoma`,
+  `macular_degeneration`, `hemianopia`, `tunnel_vision`, `cataract`,
+  `floaters`, `photophobia`, `nyctalopia` (night-blindness). All implemented
+  as composable single-pass image operations in linear sRGB. `glaucoma` and
+  `tunnel_vision` apply a radial vignette mask; `hemianopia` blanks the
+  appropriate half-field; `macular_degeneration` blurs and dims the foveal
+  region; `cataract` adds a haze overlay; `floaters` composites translucent
+  blobs; `photophobia` brightens and halates highlights; `nyctalopia` darkens
+  and desaturates the image.
+- **Pipeline support** via `sensus_core::pipeline`: apply multiple filters
+  in sequence in a single command with `--filter f1 --filter f2 …`.
+- **tetrachromacy** exploration filter (#3): expands the chrominance gamut
+  to simulate four-cone perception. Implemented via a heuristic gamut
+  expansion in LMS space.
+- First stable crates.io release (`v0.1.0`). `sensus-core` and `sensus` are
+  now published; `cargo install sensus` is the recommended install path (#12).
 - **Phase 2 focus / refraction filters** (#4): `myopia`, `hyperopia`,
   `presbyopia`, `astigmatism`. All implemented as **disk (pillbox) blur**
   in linear sRGB — Gaussian is intentionally rejected because the
@@ -43,8 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `strength` values. `achromatopsia` uses CIE photopic luminance with
   BT.709 primaries (`0.2126 R + 0.7152 G + 0.0722 B`); BT.601 is
   intentionally avoided. Alpha is preserved.
-- `sensus_core::apply()` now dispatches the four Phase 1 filters and only
-  returns `Error::NotImplemented` for the remaining variants.
+- `sensus_core::apply()` dispatches all implemented filters and returns
+  `Error::NotImplemented` only for variants not yet landed.
 - CLI now writes the transformed image to `--output` on success
   (exit code `0`) for any implemented filter.
 - Cargo workspace scaffold with two crates: `sensus-core` (pure logic) and
@@ -56,20 +72,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sensus_core::Error` (thiserror-derived) with `NotImplemented(Filter)`
   and `Image(image::ImageError)` variants, and `sensus_core::Result<T>`
   alias. (#1)
-- `sensus_core::vision::{protanopia, deuteranopia, tritanopia,
-  achromatopsia}` function stubs ready for Phase 1 (#2). (#1)
-- CLI argument parsing via clap derive — `--input`, `--output`, `--filter`,
-  `--strength` — covering all planned vision filter names. CLI logic is
-  split into `main` / `run()` for testability; filters are not yet
-  implemented and the binary exits with code `2` and a "not implemented"
-  message. (#1)
 - GitHub Actions workflows: `ci.yml` (test / fmt / clippy with
   `--all-targets --locked`) and `release.yml` (tag-driven build with
   `-p sensus --locked` for x86_64-linux, x86_64-apple, aarch64-apple,
   x86_64-windows; uploads tarballs / zips to GitHub Releases). (#1)
-- Documentation: `README.md` (English, end-user master, with scaffold-era
-  install / git-dep instructions), `docs/overview.md` (English, design),
-  `docs/roadmap.md` (Japanese, phase tracker), `CLAUDE.md` (Japanese,
-  AI-facing internal notes). universal-experience is documented as a
-  Flutter app (no Tauri). (#1)
+- Documentation: `README.md` (English, end-user master), `docs/overview.md`
+  (English, design), `docs/roadmap.md` (Japanese, phase tracker),
+  `CLAUDE.md` (Japanese, AI-facing internal notes). (#1)
 - MIT license. (#1)
+
+[0.1.0]: https://github.com/kako-jun/sensus/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,7 +916,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "sensus"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "clap",
  "image",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "sensus-core"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "image",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/core", "crates/cli"]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 authors = ["kako-jun"]
 license = "MIT"
@@ -12,7 +12,7 @@ repository = "https://github.com/kako-jun/sensus"
 rust-version = "1.78.0"
 
 [workspace.dependencies]
-sensus-core = { path = "crates/core", version = "0.0.1" }
+sensus-core = { path = "crates/core", version = "0.1.0" }
 # core は features = ["png"] のみ。CLI は default-features = true で format auto-detection を有効化する
 image = { version = "0.25", default-features = false }
 clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ educational tools, and apps like
 
 ## Status
 
-Pre-release scaffold (`v0.0.x`). Filters are landing one phase at a time —
-see [`docs/roadmap.md`](docs/roadmap.md) for what is implemented today.
+**v0.1.0** — stable release on [crates.io](https://crates.io/crates/sensus).
+All Phase 1–3 vision filters are implemented. See
+[`docs/roadmap.md`](docs/roadmap.md) for the full phase tracker.
 
 ## Filters
 
@@ -19,17 +20,23 @@ see [`docs/roadmap.md`](docs/roadmap.md) for what is implemented today.
 
 | Filter | Status | Phase | Notes |
 |---|---|---|---|
-| `protanopia`           | ✅ implemented | 1 (#2) | L-cone loss (red-blind), Machado 2009 |
-| `deuteranopia`         | ✅ implemented | 1 (#2) | M-cone loss (green-blind), Machado 2009 |
-| `tritanopia`           | ✅ implemented | 1 (#2) | S-cone loss (blue-blind), Machado 2009 |
-| `achromatopsia`        | ✅ implemented | 1 (#2) | Total color blindness, BT.709 luma |
-| `tetrachromacy`        | planned | 1+ (#3) | Four-cone exploration |
-| `myopia`               | ✅ implemented | 2 (#4) | Disk blur, -6 D max |
-| `hyperopia`            | ✅ implemented | 2 (#4) | Disk blur, +4 D max |
-| `presbyopia`           | ✅ implemented | 2 (#4) | Disk blur, +3 D add max |
-| `astigmatism`          | ✅ implemented | 2 (#4) | 1D directional blur (pure cylindrical lens), configurable axis |
-| `glaucoma` / `macular-degeneration` / `hemianopia` / `tunnel-vision` | planned | 3 (#5) | Visual field defects |
-| `cataract` / `floaters` / `photophobia` / `night-blindness` | planned | 3 (#6) | Light & transparency |
+| `protanopia`            | ✅ implemented | 1 (#2) | L-cone loss (red-blind), Machado 2009 |
+| `deuteranopia`          | ✅ implemented | 1 (#2) | M-cone loss (green-blind), Machado 2009 |
+| `tritanopia`            | ✅ implemented | 1 (#2) | S-cone loss (blue-blind), Machado 2009 |
+| `achromatopsia`         | ✅ implemented | 1 (#2) | Total color blindness, BT.709 luma |
+| `tetrachromacy`         | ✅ implemented | 1+ (#3) | Four-cone exploration, gamut expansion in LMS space |
+| `myopia`                | ✅ implemented | 2 (#4) | Disk blur, -6 D max |
+| `hyperopia`             | ✅ implemented | 2 (#4) | Disk blur, +4 D max |
+| `presbyopia`            | ✅ implemented | 2 (#4) | Disk blur, +3 D add max |
+| `astigmatism`           | ✅ implemented | 2 (#4) | 1D directional blur (pure cylindrical lens), configurable axis |
+| `glaucoma`              | ✅ implemented | 3 (#5) | Radial vignette / peripheral field loss |
+| `macular_degeneration`  | ✅ implemented | 3 (#5) | Foveal blur and dimming |
+| `hemianopia`            | ✅ implemented | 3 (#5) | Half-field blanking |
+| `tunnel_vision`         | ✅ implemented | 3 (#5) | Severe radial vignette |
+| `cataract`              | ✅ implemented | 3 (#6) | Haze overlay |
+| `floaters`              | ✅ implemented | 3 (#6) | Translucent blob compositing |
+| `photophobia`           | ✅ implemented | 3 (#6) | Brightness boost and highlight halation |
+| `nyctalopia`            | ✅ implemented | 3 (#6) | Darkening and desaturation (night-blindness) |
 
 ### Hearing (Phase 4)
 
@@ -41,14 +48,6 @@ designed both as an empathy / education tool and as an early-warning primer
 for symptoms worth taking seriously.
 
 ## Install
-
-crates.io 公開は v0.1.0 から（[#12](https://github.com/kako-jun/sensus/issues/12)）。それまでは git からインストールしてください:
-
-```sh
-cargo install --git https://github.com/kako-jun/sensus
-```
-
-v0.1.0 以降は通常通り:
 
 ```sh
 cargo install sensus
@@ -71,12 +70,15 @@ sensus -i photo.png -o photo-myopia.png       --filter myopia        --strength 
 sensus -i photo.png -o photo-presbyopia.png   --filter presbyopia    --strength 0.7
 # astigmatism with explicit cylinder axis (degrees, 0..=180; default 90)
 sensus -i photo.png -o photo-astig.png        --filter astigmatism   --strength 1.0 --axis 90
-```
 
-The above commands return exit code 0 and write the transformed image to
-`-o`. Filters not yet implemented (`tetrachromacy`, `glaucoma`, etc.) exit
-with code 2 and a "not implemented" message — see
-[`docs/roadmap.md`](docs/roadmap.md) for status.
+# Phase 3: visual field defects and light conditions
+sensus -i photo.png -o photo-glaucoma.png     --filter glaucoma      --strength 1.0
+sensus -i photo.png -o photo-cataract.png     --filter cataract      --strength 0.8
+
+# Pipeline: chain multiple filters in one pass
+sensus -i photo.png -o out.png --filter deuteranopia --filter myopia --strength 1.0
+sensus -i photo.png -o out.png --filter glaucoma --filter cataract --strength 0.7
+```
 
 Flags:
 
@@ -98,8 +100,7 @@ get a `DynamicImage` out.
 ```toml
 # Cargo.toml
 [dependencies]
-# crates.io 公開（v0.1.0）まではgit依存で
-sensus-core = { git = "https://github.com/kako-jun/sensus" }
+sensus-core = "0.1"
 ```
 
 ```rust


### PR DESCRIPTION
## 関連 Issue
closes #12

## 変更内容
- Cargo.toml: version 0.0.1 → 0.1.0
- README.md: 全フィルタ実装済みに更新、pipeline 例追加、cargo install 追加
- CHANGELOG.md: [Unreleased] → [0.1.0] - 2026-05-22

## dry-run 結果
- sensus-core: ✅ 成功
- sensus: sensus-core の crates.io 未公開のため依存解決失敗（コードの問題ではない）

## マージ後の作業
1. `cargo publish -p sensus-core`
2. `cargo publish -p sensus`
3. GitHub Release tag `v0.1.0` 作成