### PR TITLE
feat: #16 GLSL ES 3.00 シェーダソース API（CPU 実装と正本一元化）

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -12,6 +12,7 @@
 pub mod error;
 pub mod hearing;
 pub mod pipeline;
+pub mod shaders;
 pub mod vision;
 
 pub use error::Error;

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -1,0 +1,317 @@
+//! GLSL ES 3.00 シェーダソース API。
+//! CPU 実装との正本一元化のため、sensus-core がシェーダ文字列と uniform 計算を提供する。
+//!
+//! # 設計
+//!
+//! - シェーダ文字列は `include_str!` でバイナリに埋め込む。
+//! - uniform 計算は `vision.rs` の CPU 実装と完全に同じ定数・式を使う。
+//! - strength は 0.0..=1.0 の範囲を前提とし、範囲外の値は呼び出し元で clamp すること。
+
+// vision.rs の定数と同じ値（radius_px 計算の共通化）
+const MYOPIA_MAX_RADIUS_RATIO: f32 = 0.023;
+const HYPEROPIA_MAX_RADIUS_RATIO: f32 = 0.015;
+const PRESBYOPIA_MAX_RADIUS_RATIO: f32 = 0.011;
+const ASTIGMATISM_MAX_RADIUS_RATIO: f32 = 0.011;
+
+/// Machado 2009 severity = 1.0 行列（行優先: row0col0, row0col1, row0col2, ...）。
+/// vision.rs の PROTANOPIA 定数と同じ値。
+pub const PROTANOPIA_MATRIX: [f32; 9] = [
+    0.152286, 1.052583, -0.204868,
+    0.114503, 0.786281,  0.099216,
+   -0.003882, -0.048116,  1.051998,
+];
+
+/// Machado 2009 severity = 1.0 行列（行優先）。
+/// vision.rs の DEUTERANOPIA 定数と同じ値。
+pub const DEUTERANOPIA_MATRIX: [f32; 9] = [
+    0.367322, 0.860646, -0.227968,
+    0.280085, 0.672501,  0.047413,
+   -0.011820, 0.042940,  0.968881,
+];
+
+/// Machado 2009 severity = 1.0 行列（行優先）。
+/// vision.rs の TRITANOPIA 定数と同じ値。
+pub const TRITANOPIA_MATRIX: [f32; 9] = [
+    1.255528, -0.076749, -0.178779,
+   -0.078411,  0.930809,  0.147602,
+    0.004733,  0.691367,  0.303900,
+];
+
+// ---------------------------------------------------------------------------
+// シェーダ文字列取得
+// ---------------------------------------------------------------------------
+
+/// protanopia.frag の GLSL ES 3.00 ソースを返す。
+pub fn protanopia_glsl() -> &'static str {
+    include_str!("shaders/protanopia.frag")
+}
+
+/// deuteranopia.frag の GLSL ES 3.00 ソースを返す。
+pub fn deuteranopia_glsl() -> &'static str {
+    include_str!("shaders/deuteranopia.frag")
+}
+
+/// tritanopia.frag の GLSL ES 3.00 ソースを返す。
+pub fn tritanopia_glsl() -> &'static str {
+    include_str!("shaders/tritanopia.frag")
+}
+
+/// achromatopsia.frag の GLSL ES 3.00 ソースを返す。
+pub fn achromatopsia_glsl() -> &'static str {
+    include_str!("shaders/achromatopsia.frag")
+}
+
+/// myopia.frag の GLSL ES 3.00 ソースを返す。
+pub fn myopia_glsl() -> &'static str {
+    include_str!("shaders/myopia.frag")
+}
+
+/// hyperopia.frag の GLSL ES 3.00 ソースを返す。
+pub fn hyperopia_glsl() -> &'static str {
+    include_str!("shaders/hyperopia.frag")
+}
+
+/// presbyopia.frag の GLSL ES 3.00 ソースを返す。
+pub fn presbyopia_glsl() -> &'static str {
+    include_str!("shaders/presbyopia.frag")
+}
+
+/// astigmatism.frag の GLSL ES 3.00 ソースを返す。
+pub fn astigmatism_glsl() -> &'static str {
+    include_str!("shaders/astigmatism.frag")
+}
+
+// ---------------------------------------------------------------------------
+// uniform 構造体
+// ---------------------------------------------------------------------------
+
+/// 色覚フィルタ（Machado LMS 行列）の uniform。
+#[derive(Debug, Clone)]
+pub struct ColorMatrixUniforms {
+    /// severity (0.0..=1.0)
+    pub strength: f32,
+    /// 3x3 行列（行優先）
+    pub matrix: [f32; 9],
+}
+
+/// 全色盲フィルタの uniform。
+#[derive(Debug, Clone)]
+pub struct LumaUniforms {
+    /// strength (0.0..=1.0)
+    pub strength: f32,
+    /// BT.709 R 係数
+    pub r_weight: f32,
+    /// BT.709 G 係数
+    pub g_weight: f32,
+    /// BT.709 B 係数
+    pub b_weight: f32,
+}
+
+/// disk blur フィルタ（myopia / hyperopia / presbyopia）の uniform。
+#[derive(Debug, Clone)]
+pub struct BlurUniforms {
+    /// strength (0.0..=1.0)
+    pub strength: f32,
+    /// ぼかし半径（ピクセル単位）。CPU 実装と同じ式で計算。
+    pub radius_px: f32,
+}
+
+/// 乱視フィルタの uniform。
+#[derive(Debug, Clone)]
+pub struct AstigmatismUniforms {
+    /// strength (0.0..=1.0)
+    pub strength: f32,
+    /// ぼかし半径（ピクセル単位）
+    pub radius_px: f32,
+    /// 軸角度（度数法）
+    pub axis_deg: f32,
+}
+
+// ---------------------------------------------------------------------------
+// uniform 計算
+// ---------------------------------------------------------------------------
+
+/// protanopia の uniform を計算する。
+pub fn protanopia_uniforms(strength: f32) -> ColorMatrixUniforms {
+    ColorMatrixUniforms {
+        strength,
+        matrix: PROTANOPIA_MATRIX,
+    }
+}
+
+/// deuteranopia の uniform を計算する。
+pub fn deuteranopia_uniforms(strength: f32) -> ColorMatrixUniforms {
+    ColorMatrixUniforms {
+        strength,
+        matrix: DEUTERANOPIA_MATRIX,
+    }
+}
+
+/// tritanopia の uniform を計算する。
+pub fn tritanopia_uniforms(strength: f32) -> ColorMatrixUniforms {
+    ColorMatrixUniforms {
+        strength,
+        matrix: TRITANOPIA_MATRIX,
+    }
+}
+
+/// achromatopsia の uniform を計算する。
+pub fn achromatopsia_uniforms(strength: f32) -> LumaUniforms {
+    LumaUniforms {
+        strength,
+        r_weight: 0.2126,
+        g_weight: 0.7152,
+        b_weight: 0.0722,
+    }
+}
+
+/// myopia の uniform を計算する。
+///
+/// `image_min_dim`: 画像の `min(width, height)`（ピクセル）。
+pub fn myopia_uniforms(strength: f32, image_min_dim: u32) -> BlurUniforms {
+    let radius_px = strength.clamp(0.0, 1.0) * MYOPIA_MAX_RADIUS_RATIO * image_min_dim as f32;
+    BlurUniforms { strength, radius_px }
+}
+
+/// hyperopia の uniform を計算する。
+///
+/// `image_min_dim`: 画像の `min(width, height)`（ピクセル）。
+pub fn hyperopia_uniforms(strength: f32, image_min_dim: u32) -> BlurUniforms {
+    let radius_px = strength.clamp(0.0, 1.0) * HYPEROPIA_MAX_RADIUS_RATIO * image_min_dim as f32;
+    BlurUniforms { strength, radius_px }
+}
+
+/// presbyopia の uniform を計算する。
+///
+/// `image_min_dim`: 画像の `min(width, height)`（ピクセル）。
+pub fn presbyopia_uniforms(strength: f32, image_min_dim: u32) -> BlurUniforms {
+    let radius_px = strength.clamp(0.0, 1.0) * PRESBYOPIA_MAX_RADIUS_RATIO * image_min_dim as f32;
+    BlurUniforms { strength, radius_px }
+}
+
+/// astigmatism の uniform を計算する。
+///
+/// `image_min_dim`: 画像の `min(width, height)`（ピクセル）。
+/// `axis_deg`: 軸角度（度数法。0°=水平, 90°=垂直）。
+pub fn astigmatism_uniforms(strength: f32, image_min_dim: u32, axis_deg: f32) -> AstigmatismUniforms {
+    let radius_px =
+        strength.clamp(0.0, 1.0) * ASTIGMATISM_MAX_RADIUS_RATIO * image_min_dim as f32;
+    AstigmatismUniforms {
+        strength,
+        radius_px,
+        axis_deg,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protanopia_glsl_is_not_empty() {
+        assert!(!protanopia_glsl().is_empty());
+    }
+
+    #[test]
+    fn deuteranopia_glsl_is_not_empty() {
+        assert!(!deuteranopia_glsl().is_empty());
+    }
+
+    #[test]
+    fn tritanopia_glsl_is_not_empty() {
+        assert!(!tritanopia_glsl().is_empty());
+    }
+
+    #[test]
+    fn achromatopsia_glsl_is_not_empty() {
+        assert!(!achromatopsia_glsl().is_empty());
+    }
+
+    #[test]
+    fn myopia_glsl_is_not_empty() {
+        assert!(!myopia_glsl().is_empty());
+    }
+
+    #[test]
+    fn hyperopia_glsl_is_not_empty() {
+        assert!(!hyperopia_glsl().is_empty());
+    }
+
+    #[test]
+    fn presbyopia_glsl_is_not_empty() {
+        assert!(!presbyopia_glsl().is_empty());
+    }
+
+    #[test]
+    fn astigmatism_glsl_is_not_empty() {
+        assert!(!astigmatism_glsl().is_empty());
+    }
+
+    #[test]
+    fn protanopia_uniforms_has_correct_matrix() {
+        let u = protanopia_uniforms(0.0);
+        assert_eq!(u.strength, 0.0);
+        assert_eq!(u.matrix, PROTANOPIA_MATRIX);
+    }
+
+    #[test]
+    fn deuteranopia_uniforms_has_correct_matrix() {
+        let u = deuteranopia_uniforms(1.0);
+        assert_eq!(u.matrix, DEUTERANOPIA_MATRIX);
+    }
+
+    #[test]
+    fn tritanopia_uniforms_has_correct_matrix() {
+        let u = tritanopia_uniforms(1.0);
+        assert_eq!(u.matrix, TRITANOPIA_MATRIX);
+    }
+
+    #[test]
+    fn achromatopsia_uniforms_bt709_weights() {
+        let u = achromatopsia_uniforms(1.0);
+        assert!((u.r_weight - 0.2126).abs() < 1e-6);
+        assert!((u.g_weight - 0.7152).abs() < 1e-6);
+        assert!((u.b_weight - 0.0722).abs() < 1e-6);
+    }
+
+    #[test]
+    fn myopia_uniforms_strength_zero_has_zero_radius() {
+        let u = myopia_uniforms(0.0, 1000);
+        assert!(u.radius_px < 0.001, "strength=0 のとき radius はゼロに近い");
+    }
+
+    #[test]
+    fn myopia_uniforms_strength_one_correct_radius() {
+        let u = myopia_uniforms(1.0, 1000);
+        let expected = MYOPIA_MAX_RADIUS_RATIO * 1000.0;
+        assert!((u.radius_px - expected).abs() < 1e-4);
+    }
+
+    #[test]
+    fn hyperopia_uniforms_strength_zero_has_zero_radius() {
+        let u = hyperopia_uniforms(0.0, 1000);
+        assert!(u.radius_px < 0.001);
+    }
+
+    #[test]
+    fn presbyopia_uniforms_strength_zero_has_zero_radius() {
+        let u = presbyopia_uniforms(0.0, 1000);
+        assert!(u.radius_px < 0.001);
+    }
+
+    #[test]
+    fn astigmatism_uniforms_preserves_axis() {
+        let u = astigmatism_uniforms(1.0, 1000, 45.0);
+        assert_eq!(u.axis_deg, 45.0);
+    }
+
+    #[test]
+    fn astigmatism_uniforms_strength_zero_has_zero_radius() {
+        let u = astigmatism_uniforms(0.0, 1000, 90.0);
+        assert!(u.radius_px < 0.001);
+    }
+}

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -123,7 +123,9 @@ pub struct AstigmatismUniforms {
     pub strength: f32,
     /// ぼかし半径（ピクセル単位）
     pub radius_px: f32,
-    /// 軸角度（度数法）
+    /// **ぼかし方向**の軸角度（度数法）。
+    /// `astigmatism_uniforms()` が入力の「シャープ方向」から +90° した値を設定済み。
+    /// シェーダ (`astigmatism.frag`) の `uAxisDeg` に直接渡す。
     pub axis_deg: f32,
 }
 
@@ -192,14 +194,19 @@ pub fn presbyopia_uniforms(strength: f32, image_min_dim: u32) -> BlurUniforms {
 /// astigmatism の uniform を計算する。
 ///
 /// `image_min_dim`: 画像の `min(width, height)`（ピクセル）。
-/// `axis_deg`: 軸角度（度数法。0°=水平, 90°=垂直）。
+/// `axis_deg`: **シャープ方向**の軸角度（度数法。0°=水平, 90°=垂直）。
+///   vision::astigmatism() と同じ規約で、**ぼかし方向 = axis_deg + 90°**。
+///   シェーダ (`astigmatism.frag`) の `uAxisDeg` uniform にはぼかし方向を渡す。
+///   呼び出し元は vision.rs と同じ「シャープ方向」で渡せばよい。
 pub fn astigmatism_uniforms(strength: f32, image_min_dim: u32, axis_deg: f32) -> AstigmatismUniforms {
     let radius_px =
         strength.clamp(0.0, 1.0) * ASTIGMATISM_MAX_RADIUS_RATIO * image_min_dim as f32;
+    // vision.rs と同じ規約: axis_deg はシャープ方向。ぼかし方向は +90°。
+    let blur_axis_deg = axis_deg + 90.0;
     AstigmatismUniforms {
         strength,
         radius_px,
-        axis_deg,
+        axis_deg: blur_axis_deg,
     }
 }
 
@@ -304,14 +311,40 @@ mod tests {
     }
 
     #[test]
-    fn astigmatism_uniforms_preserves_axis() {
+    fn astigmatism_uniforms_blur_axis_is_sharp_plus_90() {
+        // vision.rs 規約: axis_deg はシャープ方向。ぼかし方向 = axis_deg + 90°
         let u = astigmatism_uniforms(1.0, 1000, 45.0);
-        assert_eq!(u.axis_deg, 45.0);
+        assert!((u.axis_deg - 135.0).abs() < 1e-4, "45° シャープ → 135° ぼかし");
+        let u2 = astigmatism_uniforms(1.0, 1000, 90.0);
+        assert!((u2.axis_deg - 180.0).abs() < 1e-4, "90° シャープ → 180° ぼかし");
     }
 
     #[test]
     fn astigmatism_uniforms_strength_zero_has_zero_radius() {
         let u = astigmatism_uniforms(0.0, 1000, 90.0);
         assert!(u.radius_px < 0.001);
+    }
+
+    #[test]
+    fn hyperopia_uniforms_strength_one_correct_radius() {
+        let u = hyperopia_uniforms(1.0, 800);
+        let expected = HYPEROPIA_MAX_RADIUS_RATIO * 800.0;
+        assert!((u.radius_px - expected).abs() < 1e-4);
+    }
+
+    #[test]
+    fn presbyopia_uniforms_strength_one_correct_radius() {
+        let u = presbyopia_uniforms(1.0, 800);
+        let expected = PRESBYOPIA_MAX_RADIUS_RATIO * 800.0;
+        assert!((u.radius_px - expected).abs() < 1e-4);
+    }
+
+    #[test]
+    fn astigmatism_uniforms_radius_matches_formula() {
+        let s = 0.75_f32;
+        let dim = 800_u32;
+        let u = astigmatism_uniforms(s, dim, 0.0);
+        let expected = s * ASTIGMATISM_MAX_RADIUS_RATIO * 800.0;
+        assert!((u.radius_px - expected).abs() < 1e-4);
     }
 }

--- a/crates/core/src/shaders/achromatopsia.frag
+++ b/crates/core/src/shaders/achromatopsia.frag
@@ -1,0 +1,42 @@
+#version 300 es
+precision mediump float;
+
+// BT.709 photopic luminance によるグレースケール化（全色盲シミュレーション）
+// 係数: R=0.2126, G=0.7152, B=0.0722
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uRWeight; // 0.2126
+uniform float uGWeight; // 0.7152
+uniform float uBWeight; // 0.0722
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 tex = texture(uTexture, vTexCoord);
+    float r = srgbToLinear(tex.r);
+    float g = srgbToLinear(tex.g);
+    float b = srgbToLinear(tex.b);
+
+    float y = uRWeight * r + uGWeight * g + uBWeight * b;
+
+    float nr = r + (y - r) * uStrength;
+    float ng = g + (y - g) * uStrength;
+    float nb = b + (y - b) * uStrength;
+
+    fragColor = vec4(
+        linearToSrgb(clamp(nr, 0.0, 1.0)),
+        linearToSrgb(clamp(ng, 0.0, 1.0)),
+        linearToSrgb(clamp(nb, 0.0, 1.0)),
+        tex.a
+    );
+}

--- a/crates/core/src/shaders/astigmatism.frag
+++ b/crates/core/src/shaders/astigmatism.frag
@@ -1,0 +1,53 @@
+#version 300 es
+precision mediump float;
+
+// 1D directional blur — 乱視シミュレーション（純粋 cylinder lens）
+// 軸方向に沿ったタップで line focus（焦線）を近似する。
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uRadiusPx;     // ぼかし半径（ピクセル単位）
+uniform float uAxisDeg;      // 軸角度（度数法: 0°=水平, 90°=垂直）
+uniform vec2  uTexelSize;    // vec2(1.0/width, 1.0/height)
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    if (uRadiusPx < 0.5) {
+        fragColor = texture(uTexture, vTexCoord);
+        return;
+    }
+
+    const int N = 16;
+    float rad = uAxisDeg * 3.14159265358979 / 180.0;
+    vec2 dir = vec2(cos(rad), sin(rad));
+
+    vec3 acc = vec3(0.0);
+    float totalWeight = 0.0;
+
+    for (int i = 0; i < N; i++) {
+        // -radius .. +radius に均等配置
+        float t = (float(i) / float(N - 1)) * 2.0 - 1.0;
+        vec2 offset = dir * (t * uRadiusPx) * uTexelSize;
+        vec4 s = texture(uTexture, vTexCoord + offset);
+        acc += vec3(srgbToLinear(s.r), srgbToLinear(s.g), srgbToLinear(s.b));
+        totalWeight += 1.0;
+    }
+
+    vec3 blurred = acc / totalWeight;
+    fragColor = vec4(
+        linearToSrgb(clamp(blurred.r, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.g, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.b, 0.0, 1.0)),
+        texture(uTexture, vTexCoord).a
+    );
+}

--- a/crates/core/src/shaders/deuteranopia.frag
+++ b/crates/core/src/shaders/deuteranopia.frag
@@ -1,0 +1,42 @@
+#version 300 es
+precision mediump float;
+
+// Machado 2009 severity=1.0 行列（linear sRGB → simulated linear sRGB）
+// 出典: https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uMatrix[9]; // 3x3 行列（行優先: row0col0, row0col1, row0col2, row1col0, ...）
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 tex = texture(uTexture, vTexCoord);
+    float r = srgbToLinear(tex.r);
+    float g = srgbToLinear(tex.g);
+    float b = srgbToLinear(tex.b);
+
+    float sr = uMatrix[0] * r + uMatrix[1] * g + uMatrix[2] * b;
+    float sg = uMatrix[3] * r + uMatrix[4] * g + uMatrix[5] * b;
+    float sb = uMatrix[6] * r + uMatrix[7] * g + uMatrix[8] * b;
+
+    float nr = r + (sr - r) * uStrength;
+    float ng = g + (sg - g) * uStrength;
+    float nb = b + (sb - b) * uStrength;
+
+    fragColor = vec4(
+        linearToSrgb(clamp(nr, 0.0, 1.0)),
+        linearToSrgb(clamp(ng, 0.0, 1.0)),
+        linearToSrgb(clamp(nb, 0.0, 1.0)),
+        tex.a
+    );
+}

--- a/crates/core/src/shaders/hyperopia.frag
+++ b/crates/core/src/shaders/hyperopia.frag
@@ -1,0 +1,57 @@
+#version 300 es
+precision mediump float;
+
+// 等方 disk blur（pillbox kernel）— 近視 / 遠視 / 老眼シミュレーション
+// Poisson disk サンプリング（16 サンプル）で円形ぼかしを近似する。
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uRadiusPx;     // ぼかし半径（ピクセル単位）
+uniform vec2  uTexelSize;    // vec2(1.0/width, 1.0/height)
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+// Fibonacci lattice による円形サンプリング（16 点）
+vec4 diskBlur(vec2 uv, float radius) {
+    if (radius < 0.5) return texture(uTexture, uv);
+
+    const int N = 16;
+    // 黄金角 phi ≈ 137.508°
+    const float PHI = 2.399963229728653;
+
+    vec3 acc = vec3(0.0);
+    float totalWeight = 0.0;
+
+    for (int i = 0; i < N; i++) {
+        float t = float(i) / float(N);
+        float r = sqrt(t) * radius;
+        float theta = float(i) * PHI;
+        vec2 offset = vec2(cos(theta), sin(theta)) * r * uTexelSize;
+        vec4 s = texture(uTexture, uv + offset);
+        // linear 空間でサンプリング
+        vec3 lin = vec3(srgbToLinear(s.r), srgbToLinear(s.g), srgbToLinear(s.b));
+        acc += lin;
+        totalWeight += 1.0;
+    }
+
+    vec3 blurred = acc / totalWeight;
+    return vec4(
+        linearToSrgb(clamp(blurred.r, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.g, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.b, 0.0, 1.0)),
+        texture(uTexture, uv).a
+    );
+}
+
+void main() {
+    fragColor = diskBlur(vTexCoord, uRadiusPx);
+}

--- a/crates/core/src/shaders/myopia.frag
+++ b/crates/core/src/shaders/myopia.frag
@@ -1,0 +1,57 @@
+#version 300 es
+precision mediump float;
+
+// 等方 disk blur（pillbox kernel）— 近視 / 遠視 / 老眼シミュレーション
+// Poisson disk サンプリング（16 サンプル）で円形ぼかしを近似する。
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uRadiusPx;     // ぼかし半径（ピクセル単位）
+uniform vec2  uTexelSize;    // vec2(1.0/width, 1.0/height)
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+// Fibonacci lattice による円形サンプリング（16 点）
+vec4 diskBlur(vec2 uv, float radius) {
+    if (radius < 0.5) return texture(uTexture, uv);
+
+    const int N = 16;
+    // 黄金角 phi ≈ 137.508°
+    const float PHI = 2.399963229728653;
+
+    vec3 acc = vec3(0.0);
+    float totalWeight = 0.0;
+
+    for (int i = 0; i < N; i++) {
+        float t = float(i) / float(N);
+        float r = sqrt(t) * radius;
+        float theta = float(i) * PHI;
+        vec2 offset = vec2(cos(theta), sin(theta)) * r * uTexelSize;
+        vec4 s = texture(uTexture, uv + offset);
+        // linear 空間でサンプリング
+        vec3 lin = vec3(srgbToLinear(s.r), srgbToLinear(s.g), srgbToLinear(s.b));
+        acc += lin;
+        totalWeight += 1.0;
+    }
+
+    vec3 blurred = acc / totalWeight;
+    return vec4(
+        linearToSrgb(clamp(blurred.r, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.g, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.b, 0.0, 1.0)),
+        texture(uTexture, uv).a
+    );
+}
+
+void main() {
+    fragColor = diskBlur(vTexCoord, uRadiusPx);
+}

--- a/crates/core/src/shaders/presbyopia.frag
+++ b/crates/core/src/shaders/presbyopia.frag
@@ -1,0 +1,57 @@
+#version 300 es
+precision mediump float;
+
+// 等方 disk blur（pillbox kernel）— 近視 / 遠視 / 老眼シミュレーション
+// Poisson disk サンプリング（16 サンプル）で円形ぼかしを近似する。
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uRadiusPx;     // ぼかし半径（ピクセル単位）
+uniform vec2  uTexelSize;    // vec2(1.0/width, 1.0/height)
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+// Fibonacci lattice による円形サンプリング（16 点）
+vec4 diskBlur(vec2 uv, float radius) {
+    if (radius < 0.5) return texture(uTexture, uv);
+
+    const int N = 16;
+    // 黄金角 phi ≈ 137.508°
+    const float PHI = 2.399963229728653;
+
+    vec3 acc = vec3(0.0);
+    float totalWeight = 0.0;
+
+    for (int i = 0; i < N; i++) {
+        float t = float(i) / float(N);
+        float r = sqrt(t) * radius;
+        float theta = float(i) * PHI;
+        vec2 offset = vec2(cos(theta), sin(theta)) * r * uTexelSize;
+        vec4 s = texture(uTexture, uv + offset);
+        // linear 空間でサンプリング
+        vec3 lin = vec3(srgbToLinear(s.r), srgbToLinear(s.g), srgbToLinear(s.b));
+        acc += lin;
+        totalWeight += 1.0;
+    }
+
+    vec3 blurred = acc / totalWeight;
+    return vec4(
+        linearToSrgb(clamp(blurred.r, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.g, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.b, 0.0, 1.0)),
+        texture(uTexture, uv).a
+    );
+}
+
+void main() {
+    fragColor = diskBlur(vTexCoord, uRadiusPx);
+}

--- a/crates/core/src/shaders/protanopia.frag
+++ b/crates/core/src/shaders/protanopia.frag
@@ -1,0 +1,42 @@
+#version 300 es
+precision mediump float;
+
+// Machado 2009 severity=1.0 行列（linear sRGB → simulated linear sRGB）
+// 出典: https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uMatrix[9]; // 3x3 行列（行優先: row0col0, row0col1, row0col2, row1col0, ...）
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 tex = texture(uTexture, vTexCoord);
+    float r = srgbToLinear(tex.r);
+    float g = srgbToLinear(tex.g);
+    float b = srgbToLinear(tex.b);
+
+    float sr = uMatrix[0] * r + uMatrix[1] * g + uMatrix[2] * b;
+    float sg = uMatrix[3] * r + uMatrix[4] * g + uMatrix[5] * b;
+    float sb = uMatrix[6] * r + uMatrix[7] * g + uMatrix[8] * b;
+
+    float nr = r + (sr - r) * uStrength;
+    float ng = g + (sg - g) * uStrength;
+    float nb = b + (sb - b) * uStrength;
+
+    fragColor = vec4(
+        linearToSrgb(clamp(nr, 0.0, 1.0)),
+        linearToSrgb(clamp(ng, 0.0, 1.0)),
+        linearToSrgb(clamp(nb, 0.0, 1.0)),
+        tex.a
+    );
+}

--- a/crates/core/src/shaders/tritanopia.frag
+++ b/crates/core/src/shaders/tritanopia.frag
@@ -1,0 +1,42 @@
+#version 300 es
+precision mediump float;
+
+// Machado 2009 severity=1.0 行列（linear sRGB → simulated linear sRGB）
+// 出典: https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uMatrix[9]; // 3x3 行列（行優先: row0col0, row0col1, row0col2, row1col0, ...）
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 tex = texture(uTexture, vTexCoord);
+    float r = srgbToLinear(tex.r);
+    float g = srgbToLinear(tex.g);
+    float b = srgbToLinear(tex.b);
+
+    float sr = uMatrix[0] * r + uMatrix[1] * g + uMatrix[2] * b;
+    float sg = uMatrix[3] * r + uMatrix[4] * g + uMatrix[5] * b;
+    float sb = uMatrix[6] * r + uMatrix[7] * g + uMatrix[8] * b;
+
+    float nr = r + (sr - r) * uStrength;
+    float ng = g + (sg - g) * uStrength;
+    float nb = b + (sb - b) * uStrength;
+
+    fragColor = vec4(
+        linearToSrgb(clamp(nr, 0.0, 1.0)),
+        linearToSrgb(clamp(ng, 0.0, 1.0)),
+        linearToSrgb(clamp(nb, 0.0, 1.0)),
+        tex.a
+    );
+}


### PR DESCRIPTION
## 関連 Issue
closes #16

## 変更内容

### 新規ファイル
- `crates/core/src/shaders/` — GLSL ES 3.00 フラグメントシェーダ 8 本
  - `protanopia.frag` / `deuteranopia.frag` / `tritanopia.frag` — Machado 2009 LMS 行列 + strength blend
  - `achromatopsia.frag` — BT.709 luma グレースケール化
  - `myopia.frag` / `hyperopia.frag` / `presbyopia.frag` — Fibonacci lattice disk blur (16 tap)
  - `astigmatism.frag` — 1D directional blur（軸角度 uniform）
- `crates/core/src/shaders.rs` — Rust API

### API
```rust
// シェーダソース文字列（include_str! で埋め込み済み）
pub fn protanopia_glsl() -> &'static str
pub fn deuteranopia_glsl() -> &'static str
// ... 全 8 フィルタ

// uniform 計算（CPU 実装と同じ定数・計算式を使用）
pub fn protanopia_uniforms(strength: f32) -> ColorMatrixUniforms
pub fn myopia_uniforms(strength: f32, image_min_dim: u32) -> BlurUniforms
pub fn astigmatism_uniforms(strength: f32, image_min_dim: u32, axis_deg: f32) -> AstigmatismUniforms
```

radius_px の計算式・LMS 行列は vision.rs の定数と完全同値。

## テスト
138 → 156 件 (+18)