### PR TITLE
feat: #29 diplopia / nystagmus / starbursts を追加

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -152,19 +152,19 @@ struct Cli {
     focus: f32,
 
     /// Diplopia horizontal offset in min(W,H) ratio (-1.0..=1.0). Default: 0.02
-    #[arg(long, default_value = "0.02")]
+    #[arg(long, default_value = "0.02", value_parser = parse_signed_ratio)]
     offset_x: f32,
 
     /// Diplopia vertical offset in min(W,H) ratio (-1.0..=1.0). Default: 0.01
-    #[arg(long, default_value = "0.01")]
+    #[arg(long, default_value = "0.01", value_parser = parse_signed_ratio)]
     offset_y: f32,
 
     /// Diplopia ghost image strength (0.0..=1.0). Default: 0.7
-    #[arg(long, default_value = "0.7")]
+    #[arg(long, default_value = "0.7", value_parser = parse_ratio)]
     ghost_strength: f32,
 
     /// Nystagmus amplitude in min(W,H) ratio. Default: 0.03
-    #[arg(long, default_value = "0.03")]
+    #[arg(long, default_value = "0.03", value_parser = parse_ratio)]
     amplitude: f32,
 
     /// Nystagmus direction in degrees (0=horizontal, 90=vertical). Default: 0.0
@@ -176,11 +176,11 @@ struct Cli {
     num_rays: u32,
 
     /// Starbursts ray length in min(W,H) ratio. Default: 0.1
-    #[arg(long, default_value = "0.1")]
+    #[arg(long, default_value = "0.1", value_parser = parse_ratio)]
     ray_length: f32,
 
     /// Starbursts brightness threshold (0.0..=1.0). Default: 0.8
-    #[arg(long, default_value = "0.8")]
+    #[arg(long, default_value = "0.8", value_parser = parse_ratio)]
     threshold: f32,
 }
 
@@ -192,6 +192,28 @@ fn parse_strength(s: &str) -> Result<f32, String> {
         .map_err(|e: std::num::ParseFloatError| e.to_string())?;
     if v.is_nan() || !(0.0..=1.0).contains(&v) {
         return Err(format!("strength must be in 0.0..=1.0, got {v}"));
+    }
+    Ok(v)
+}
+
+/// Parse a ratio argument in `0.0..=1.0` (ghost-strength, amplitude, ray-length, threshold 等).
+fn parse_ratio(s: &str) -> Result<f32, String> {
+    let v: f32 = s
+        .parse()
+        .map_err(|e: std::num::ParseFloatError| e.to_string())?;
+    if v.is_nan() || !(0.0..=1.0).contains(&v) {
+        return Err(format!("value must be in 0.0..=1.0, got {v}"));
+    }
+    Ok(v)
+}
+
+/// Parse a signed offset ratio in `-1.0..=1.0` (offset-x, offset-y).
+fn parse_signed_ratio(s: &str) -> Result<f32, String> {
+    let v: f32 = s
+        .parse()
+        .map_err(|e: std::num::ParseFloatError| e.to_string())?;
+    if v.is_nan() || !(-1.0..=1.0).contains(&v) {
+        return Err(format!("value must be in -1.0..=1.0, got {v}"));
     }
     Ok(v)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -38,6 +38,10 @@ enum Filter {
     Vertigo,
     BppvRotation,
     VestibularNeuritis,
+    // Phase 4: 眼振・複視・スターバースト (Issue #29)
+    Diplopia,
+    Nystagmus,
+    Starbursts,
     // Phase N: 深度マップ対応距離依存ぼけ (Issue #19)
     MyopiaDepth,
     HyperopiaDepth,
@@ -81,6 +85,9 @@ impl Filter {
             Filter::Vertigo => CoreFilter::Vertigo,
             Filter::BppvRotation => CoreFilter::BppvRotation,
             Filter::VestibularNeuritis => CoreFilter::VestibularNeuritis,
+            Filter::Diplopia => CoreFilter::Diplopia,
+            Filter::Nystagmus => CoreFilter::Nystagmus,
+            Filter::Starbursts => CoreFilter::Starbursts,
             Filter::MyopiaDepth | Filter::HyperopiaDepth | Filter::DepthOfField => {
                 // depth フィルタは pipeline を通さないため、ここには来ない
                 unreachable!("depth filters must be handled separately")
@@ -143,6 +150,38 @@ struct Cli {
     /// Focus depth in 0.0..=1.0 (bright=near, dark=far). Only used with depth blur filters.
     #[arg(long, default_value = "0.5", value_parser = parse_focus)]
     focus: f32,
+
+    /// Diplopia horizontal offset in min(W,H) ratio (-1.0..=1.0). Default: 0.02
+    #[arg(long, default_value = "0.02")]
+    offset_x: f32,
+
+    /// Diplopia vertical offset in min(W,H) ratio (-1.0..=1.0). Default: 0.01
+    #[arg(long, default_value = "0.01")]
+    offset_y: f32,
+
+    /// Diplopia ghost image strength (0.0..=1.0). Default: 0.7
+    #[arg(long, default_value = "0.7")]
+    ghost_strength: f32,
+
+    /// Nystagmus amplitude in min(W,H) ratio. Default: 0.03
+    #[arg(long, default_value = "0.03")]
+    amplitude: f32,
+
+    /// Nystagmus direction in degrees (0=horizontal, 90=vertical). Default: 0.0
+    #[arg(long, default_value = "0.0")]
+    direction_deg: f32,
+
+    /// Starbursts number of rays. Default: 6
+    #[arg(long, default_value = "6")]
+    num_rays: u32,
+
+    /// Starbursts ray length in min(W,H) ratio. Default: 0.1
+    #[arg(long, default_value = "0.1")]
+    ray_length: f32,
+
+    /// Starbursts brightness threshold (0.0..=1.0). Default: 0.8
+    #[arg(long, default_value = "0.8")]
+    threshold: f32,
 }
 
 /// Parse the `--strength` argument and reject values outside `0.0..=1.0`
@@ -272,6 +311,14 @@ fn run(cli: Cli) -> Result<(), RunError> {
         step.gaze_x = cli.gaze_x;
         step.gaze_y = cli.gaze_y;
         step.side = cli.side;
+        step.offset_x = cli.offset_x;
+        step.offset_y = cli.offset_y;
+        step.ghost_strength = cli.ghost_strength;
+        step.amplitude = cli.amplitude;
+        step.direction_deg = cli.direction_deg;
+        step.num_rays = cli.num_rays;
+        step.ray_length_ratio = cli.ray_length;
+        step.threshold = cli.threshold;
         pipeline = pipeline.push(step);
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -54,6 +54,10 @@ pub enum Filter {
     Vertigo,
     BppvRotation,
     VestibularNeuritis,
+    // vision (Phase 4 / #29: diplopia / nystagmus / starbursts)
+    Diplopia,
+    Nystagmus,
+    Starbursts,
 }
 
 /// Apply a [`Filter`] to an image at a given strength (`0.0..=1.0`).
@@ -89,6 +93,9 @@ pub fn apply(
         Filter::Vertigo => vision::vertigo(img, strength, 0.0),
         Filter::BppvRotation => vision::bppv_rotation(img, strength, 0.0),
         Filter::VestibularNeuritis => vision::vestibular_neuritis(img, strength),
+        Filter::Diplopia => vision::diplopia(img, strength, 0.02, 0.01, 0.7),
+        Filter::Nystagmus => vision::nystagmus(img, strength, 0.03, 0.0),
+        Filter::Starbursts => vision::starbursts(img, strength, 6, 0.1, 0.8),
     }
 }
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -24,6 +24,22 @@ pub struct FilterStep {
     pub gaze_y: f32,
     /// hemianopia 用側（0.0=左視野消失, 1.0=右視野消失）。デフォルト: 0.0
     pub side: f32,
+    /// diplopia 水平ずれ（min(W,H) 比）。デフォルト: 0.02
+    pub offset_x: f32,
+    /// diplopia 垂直ずれ（min(W,H) 比）。デフォルト: 0.01
+    pub offset_y: f32,
+    /// diplopia 幽霊像強度。デフォルト: 0.7
+    pub ghost_strength: f32,
+    /// nystagmus 振幅（min(W,H) 比）。デフォルト: 0.03
+    pub amplitude: f32,
+    /// nystagmus 方向（0°=水平, 90°=垂直）。デフォルト: 0.0
+    pub direction_deg: f32,
+    /// starbursts 光芒数。デフォルト: 6
+    pub num_rays: u32,
+    /// starbursts 光芒長（min(W,H) 比）。デフォルト: 0.1
+    pub ray_length_ratio: f32,
+    /// starbursts 輝度閾値。デフォルト: 0.8
+    pub threshold: f32,
 }
 
 impl FilterStep {
@@ -38,6 +54,14 @@ impl FilterStep {
             gaze_x: 0.5,
             gaze_y: 0.5,
             side: 0.0,
+            offset_x: 0.02,
+            offset_y: 0.01,
+            ghost_strength: 0.7,
+            amplitude: 0.03,
+            direction_deg: 0.0,
+            num_rays: 6,
+            ray_length_ratio: 0.1,
+            threshold: 0.8,
         }
     }
 
@@ -51,6 +75,9 @@ impl FilterStep {
             Filter::Photophobia => vision::photophobia(img, self.strength),
             Filter::NightBlindness => vision::nyctalopia(img, self.strength),
             Filter::Hemianopia => vision::hemianopia(img, self.strength, self.side),
+            Filter::Diplopia => vision::diplopia(img, self.strength, self.offset_x, self.offset_y, self.ghost_strength),
+            Filter::Nystagmus => vision::nystagmus(img, self.strength, self.amplitude, self.direction_deg),
+            Filter::Starbursts => vision::starbursts(img, self.strength, self.num_rays, self.ray_length_ratio, self.threshold),
             f => crate::apply(f, img, self.strength),
         }
     }

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -81,6 +81,21 @@ pub fn astigmatism_glsl() -> &'static str {
     include_str!("shaders/astigmatism.frag")
 }
 
+/// diplopia.frag の GLSL ES 3.00 ソースを返す。
+pub fn diplopia_glsl() -> &'static str {
+    include_str!("shaders/diplopia.frag")
+}
+
+/// nystagmus.frag の GLSL ES 3.00 ソースを返す。
+pub fn nystagmus_glsl() -> &'static str {
+    include_str!("shaders/nystagmus.frag")
+}
+
+/// starbursts.frag の GLSL ES 3.00 ソースを返す。
+pub fn starbursts_glsl() -> &'static str {
+    include_str!("shaders/starbursts.frag")
+}
+
 // ---------------------------------------------------------------------------
 // uniform 構造体
 // ---------------------------------------------------------------------------
@@ -208,6 +223,69 @@ pub fn astigmatism_uniforms(strength: f32, image_min_dim: u32, axis_deg: f32) ->
         radius_px,
         axis_deg: blur_axis_deg,
     }
+}
+
+/// 複視フィルタの uniform。
+#[derive(Debug, Clone)]
+pub struct DiploiaUniforms {
+    pub strength: f32,
+    /// dx（テクセル単位 = dx_px / width）
+    pub offset_x_texel: f32,
+    /// dy（テクセル単位 = dy_px / height）
+    pub offset_y_texel: f32,
+    pub ghost_strength: f32,
+}
+
+/// 眼振フィルタの uniform。
+#[derive(Debug, Clone)]
+pub struct NystagmusUniforms {
+    pub strength: f32,
+    pub radius_px: f32,
+    pub direction_deg: f32,
+}
+
+/// スターバーストフィルタの uniform。
+#[derive(Debug, Clone)]
+pub struct StarburstsUniforms {
+    pub strength: f32,
+    pub threshold: f32,
+}
+
+/// diplopia の uniform を計算する。
+pub fn diplopia_uniforms(
+    strength: f32,
+    offset_x_px: f32,
+    offset_y_px: f32,
+    ghost_strength: f32,
+    width: u32,
+    height: u32,
+) -> DiploiaUniforms {
+    DiploiaUniforms {
+        strength,
+        offset_x_texel: offset_x_px / width as f32,
+        offset_y_texel: offset_y_px / height as f32,
+        ghost_strength,
+    }
+}
+
+/// nystagmus の uniform を計算する。
+pub fn nystagmus_uniforms(
+    strength: f32,
+    amplitude: f32,
+    direction_deg: f32,
+    image_min_dim: u32,
+) -> NystagmusUniforms {
+    let radius_px = amplitude.clamp(0.0, 1.0) * strength.clamp(0.0, 1.0) * image_min_dim as f32;
+    NystagmusUniforms {
+        strength,
+        radius_px,
+        direction_deg,
+    }
+}
+
+/// starbursts の uniform を計算する。
+pub fn starbursts_uniforms(strength: f32, threshold: f32) -> StarburstsUniforms {
+    StarburstsUniforms { strength, threshold }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -227,7 +227,7 @@ pub fn astigmatism_uniforms(strength: f32, image_min_dim: u32, axis_deg: f32) ->
 
 /// 複視フィルタの uniform。
 #[derive(Debug, Clone)]
-pub struct DiploiaUniforms {
+pub struct DiplopiaUniforms {
     pub strength: f32,
     /// dx（テクセル単位 = dx_px / width）
     pub offset_x_texel: f32,
@@ -259,8 +259,8 @@ pub fn diplopia_uniforms(
     ghost_strength: f32,
     width: u32,
     height: u32,
-) -> DiploiaUniforms {
-    DiploiaUniforms {
+) -> DiplopiaUniforms {
+    DiplopiaUniforms {
         strength,
         offset_x_texel: offset_x_px / width as f32,
         offset_y_texel: offset_y_px / height as f32,

--- a/crates/core/src/shaders/diplopia.frag
+++ b/crates/core/src/shaders/diplopia.frag
@@ -1,0 +1,37 @@
+#version 300 es
+precision mediump float;
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uOffsetX;   // dx（テクセル単位 = dx_px / width）
+uniform float uOffsetY;   // dy（テクセル単位 = dy_px / height）
+uniform float uGhostStrength;
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 orig = texture(uTexture, vTexCoord);
+    vec2 ghostUV = clamp(vTexCoord - vec2(uOffsetX, uOffsetY), 0.0, 1.0);
+    vec4 ghost = texture(uTexture, ghostUV);
+
+    float alpha = uGhostStrength * uStrength;
+
+    vec3 o = vec3(srgbToLinear(orig.r), srgbToLinear(orig.g), srgbToLinear(orig.b));
+    vec3 g = vec3(srgbToLinear(ghost.r), srgbToLinear(ghost.g), srgbToLinear(ghost.b));
+    vec3 blended = mix(o, o + g * alpha, uStrength);
+
+    fragColor = vec4(
+        linearToSrgb(clamp(blended.r, 0.0, 1.0)),
+        linearToSrgb(clamp(blended.g, 0.0, 1.0)),
+        linearToSrgb(clamp(blended.b, 0.0, 1.0)),
+        orig.a
+    );
+}

--- a/crates/core/src/shaders/nystagmus.frag
+++ b/crates/core/src/shaders/nystagmus.frag
@@ -1,0 +1,53 @@
+#version 300 es
+precision mediump float;
+
+// 1D directional blur — 眼振シミュレーション（motion blur による方向性ぼけ）
+// astigmatism.frag と同構造（16 tap）。
+// uniform 名のみ変更: uAxisDeg → uDirectionDeg, uRadiusPx（同名）, uTexelSize（同名）。
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uRadiusPx;       // ぼかし半径（ピクセル単位）
+uniform float uDirectionDeg;   // 揺れ方向（度数法: 0°=水平, 90°=垂直）
+uniform vec2  uTexelSize;      // vec2(1.0/width, 1.0/height)
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    if (uRadiusPx < 0.5) {
+        fragColor = texture(uTexture, vTexCoord);
+        return;
+    }
+
+    const int N = 16;
+    float rad = uDirectionDeg * 3.14159265358979 / 180.0;
+    vec2 dir = vec2(cos(rad), sin(rad));
+
+    vec3 acc = vec3(0.0);
+    float totalWeight = 0.0;
+
+    for (int i = 0; i < N; i++) {
+        float t = (float(i) / float(N - 1)) * 2.0 - 1.0;
+        vec2 offset = dir * (t * uRadiusPx) * uTexelSize;
+        vec4 s = texture(uTexture, vTexCoord + offset);
+        acc += vec3(srgbToLinear(s.r), srgbToLinear(s.g), srgbToLinear(s.b));
+        totalWeight += 1.0;
+    }
+
+    vec3 blurred = acc / totalWeight;
+    fragColor = vec4(
+        linearToSrgb(clamp(blurred.r, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.g, 0.0, 1.0)),
+        linearToSrgb(clamp(blurred.b, 0.0, 1.0)),
+        texture(uTexture, vTexCoord).a
+    );
+}

--- a/crates/core/src/shaders/starbursts.frag
+++ b/crates/core/src/shaders/starbursts.frag
@@ -1,0 +1,44 @@
+#version 300 es
+precision mediump float;
+
+// スターバースト（輝度閾値マスク）シミュレーション。
+// GPU 上でのフルレイマーチングは重いため、輝度が threshold を超える画素を
+// 強調するシンプルなブライトニングを行う。
+// フルレイマーチング版は CPU 実装（vision::starbursts）を参照。
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uThreshold;
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 orig = texture(uTexture, vTexCoord);
+    float rl = srgbToLinear(orig.r);
+    float gl = srgbToLinear(orig.g);
+    float bl = srgbToLinear(orig.b);
+
+    // BT.709 輝度
+    float luma = 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+
+    if (luma > uThreshold) {
+        float excess = (luma - uThreshold) / max(1.0 - uThreshold, 0.001);
+        float boost = excess * uStrength;
+        fragColor = vec4(
+            linearToSrgb(clamp(rl + boost, 0.0, 1.0)),
+            linearToSrgb(clamp(gl + boost, 0.0, 1.0)),
+            linearToSrgb(clamp(bl + boost, 0.0, 1.0)),
+            orig.a
+        );
+    } else {
+        fragColor = orig;
+    }
+}

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -1540,6 +1540,210 @@ pub fn tunnel_vision(img: DynamicImage, strength: f32) -> crate::Result<DynamicI
     Ok(DynamicImage::ImageRgba8(out_rgba))
 }
 
+// -------------------------------------------------------------------------
+// Phase 4 / #29: diplopia / nystagmus / starbursts
+// -------------------------------------------------------------------------
+
+/// 複視（Diplopia）シミュレーション。
+///
+/// 元画像を `(offset_x, offset_y)` ピクセルだけ平行移動した「幽霊像」を
+/// `ghost_strength * strength` の強度でアルファブレンドして合成する。
+///
+/// # 引数
+/// - `strength`: エフェクト全体強度（0.0..=1.0）
+/// - `offset_x`: 水平ずれ（min(W,H) 比、−1.0..=1.0）
+/// - `offset_y`: 垂直ずれ（min(W,H) 比、−1.0..=1.0）
+/// - `ghost_strength`: 幽霊像の見えやすさ（0.0..=1.0）
+pub fn diplopia(
+    img: DynamicImage,
+    strength: f32,
+    offset_x: f32,
+    offset_y: f32,
+    ghost_strength: f32,
+) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    if s == 0.0 {
+        return Ok(img);
+    }
+
+    let rgba = img.to_rgba8();
+    let width = rgba.width();
+    let height = rgba.height();
+    let min_dim = width.min(height) as f32;
+
+    let dx = (offset_x * min_dim).round() as i32;
+    let dy = (offset_y * min_dim).round() as i32;
+    let ghost_alpha = ghost_strength.clamp(0.0, 1.0) * s;
+
+    let mut out = RgbaImage::new(width, height);
+    for y in 0..height as i32 {
+        for x in 0..width as i32 {
+            let orig_px = rgba.get_pixel(x as u32, y as u32);
+
+            // 幽霊のソース座標（エッジクランプ）
+            let src_x = (x - dx).clamp(0, width as i32 - 1) as u32;
+            let src_y = (y - dy).clamp(0, height as i32 - 1) as u32;
+            let ghost_px = rgba.get_pixel(src_x, src_y);
+
+            // linear sRGB でアルファブレンド
+            let o = [
+                srgb_to_linear(orig_px[0] as f32 / 255.0),
+                srgb_to_linear(orig_px[1] as f32 / 255.0),
+                srgb_to_linear(orig_px[2] as f32 / 255.0),
+            ];
+            let g = [
+                srgb_to_linear(ghost_px[0] as f32 / 255.0),
+                srgb_to_linear(ghost_px[1] as f32 / 255.0),
+                srgb_to_linear(ghost_px[2] as f32 / 255.0),
+            ];
+            let blended = [
+                lerp(o[0], o[0] + g[0] * ghost_alpha, s).clamp(0.0, 1.0),
+                lerp(o[1], o[1] + g[1] * ghost_alpha, s).clamp(0.0, 1.0),
+                lerp(o[2], o[2] + g[2] * ghost_alpha, s).clamp(0.0, 1.0),
+            ];
+
+            out.put_pixel(
+                x as u32,
+                y as u32,
+                image::Rgba([
+                    pack_u8(linear_to_srgb(blended[0])),
+                    pack_u8(linear_to_srgb(blended[1])),
+                    pack_u8(linear_to_srgb(blended[2])),
+                    orig_px[3],
+                ]),
+            );
+        }
+    }
+
+    Ok(DynamicImage::ImageRgba8(out))
+}
+
+/// 眼振（Nystagmus）シミュレーション。
+///
+/// 目が周期的に揺れることで生じる motion blur を
+/// 1D directional blur（astigmatism と同構造）で表現する。
+///
+/// # 引数
+/// - `strength`: エフェクト強度（0.0..=1.0）
+/// - `amplitude`: 揺れ幅（min(W,H) 比）
+/// - `direction_deg`: 揺れ方向（0°=水平, 90°=垂直）
+pub fn nystagmus(
+    img: DynamicImage,
+    strength: f32,
+    amplitude: f32,
+    direction_deg: f32,
+) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    let rgba = img.to_rgba8();
+    let width = rgba.width();
+    let height = rgba.height();
+    let min_dim = width.min(height) as f32;
+
+    let radius_px = amplitude.clamp(0.0, 1.0) * s * min_dim;
+
+    if s == 0.0 || radius_px < MIN_BLUR_RADIUS_PX {
+        return Ok(DynamicImage::ImageRgba8(rgba));
+    }
+
+    // 揺れ方向をそのままぼかし方向として使用（astigmatism と異なり +90° しない）
+    let blur_axis_rad = direction_deg.to_radians();
+
+    let (linear, alpha) = rgba_to_linear_planes(&rgba);
+    // 1D directional blur: 短軸を MIN_BLUR_RADIUS_PX に縮退
+    let blurred = ellipse_blur(&linear, width, height, radius_px, MIN_BLUR_RADIUS_PX, blur_axis_rad);
+    let out = linear_planes_to_rgba(&blurred, &alpha, width, height);
+    Ok(DynamicImage::ImageRgba8(out))
+}
+
+/// スターバースト（Starbursts）シミュレーション。
+///
+/// 強い光源から放射状の光芒が伸びる現象（乱視・白内障術後など）を表現する。
+///
+/// # 引数
+/// - `strength`: エフェクト強度（0.0..=1.0）
+/// - `num_rays`: 光芒の本数（4/6/8 推奨）
+/// - `ray_length_ratio`: 光芒の長さ（min(W,H) 比）
+/// - `threshold`: 光芒が発生する輝度閾値（0.0..=1.0）
+pub fn starbursts(
+    img: DynamicImage,
+    strength: f32,
+    num_rays: u32,
+    ray_length_ratio: f32,
+    threshold: f32,
+) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    if s == 0.0 {
+        return Ok(img);
+    }
+
+    let rgba = img.to_rgba8();
+    let width = rgba.width();
+    let height = rgba.height();
+    let min_dim = width.min(height) as f32;
+
+    let ray_length_px = (ray_length_ratio.clamp(0.0, 1.0) * min_dim) as u32;
+    let threshold = threshold.clamp(0.0, 1.0);
+
+    // 光芒レイヤー（linear sRGB, f32）
+    let mut ray_layer: Vec<[f32; 3]> = vec![[0.0; 3]; (width * height) as usize];
+
+    // BT.709 輝度計算用定数
+    const R_LUMA: f32 = 0.2126;
+    const G_LUMA: f32 = 0.7152;
+    const B_LUMA: f32 = 0.0722;
+
+    use std::f32::consts::PI;
+
+    for y in 0..height {
+        for x in 0..width {
+            let px = rgba.get_pixel(x, y);
+            let rl = srgb_to_linear(px[0] as f32 / 255.0);
+            let gl = srgb_to_linear(px[1] as f32 / 255.0);
+            let bl = srgb_to_linear(px[2] as f32 / 255.0);
+            let luma = R_LUMA * rl + G_LUMA * gl + B_LUMA * bl;
+
+            if luma <= threshold || num_rays == 0 || ray_length_px == 0 {
+                continue;
+            }
+
+            let src_intensity = (luma - threshold) / (1.0 - threshold).max(1e-6);
+
+            for i in 0..num_rays {
+                let theta = i as f32 * 2.0 * PI / num_rays as f32;
+                let cos_t = theta.cos();
+                let sin_t = theta.sin();
+
+                for t in 1..=ray_length_px {
+                    let sx = x as i32 + (t as f32 * cos_t).round() as i32;
+                    let sy = y as i32 + (t as f32 * sin_t).round() as i32;
+                    if sx < 0 || sx >= width as i32 || sy < 0 || sy >= height as i32 {
+                        continue;
+                    }
+                    let weight = src_intensity * (1.0 - t as f32 / ray_length_px as f32) * s;
+                    let idx = sy as usize * width as usize + sx as usize;
+                    ray_layer[idx][0] += weight;
+                    ray_layer[idx][1] += weight;
+                    ray_layer[idx][2] += weight;
+                }
+            }
+        }
+    }
+
+    // 元画像 linear + 光芒レイヤー を合成
+    let (linear, alpha) = rgba_to_linear_planes(&rgba);
+    let mut out_linear: Vec<[f32; 3]> = Vec::with_capacity(linear.len());
+    for (i, orig) in linear.iter().enumerate() {
+        out_linear.push([
+            (orig[0] + ray_layer[i][0]).clamp(0.0, 1.0),
+            (orig[1] + ray_layer[i][1]).clamp(0.0, 1.0),
+            (orig[2] + ray_layer[i][2]).clamp(0.0, 1.0),
+        ]);
+    }
+
+    let out = linear_planes_to_rgba(&out_linear, &alpha, width, height);
+    Ok(DynamicImage::ImageRgba8(out))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3345,5 +3549,121 @@ mod tests {
             "near pixel (depth=1.0 > focus=0.0) must be more blurred than focus pixel: \
              blurred_center={blurred_center}, sharp_center={sharp_center}"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // #29: diplopia / nystagmus / starbursts
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn diplopia_shifts_ghost_image() {
+        // 32x32、左半分を白、右半分を黒にして右に少しずらす
+        let size = 32_u32;
+        let mut img = RgbaImage::from_pixel(size, size, Rgba([0, 0, 0, 255]));
+        // 左半分を白
+        for y in 0..size {
+            for x in 0..(size / 2) {
+                img.put_pixel(x, y, Rgba([255, 255, 255, 255]));
+            }
+        }
+        // 右半分の左端（x = size/2）の元の値は 0
+        let check_x = size / 2;
+        let check_y = size / 2;
+        let orig_px = img.get_pixel(check_x, check_y)[0];
+        assert_eq!(orig_px, 0, "original should be black at check point");
+
+        let input = DynamicImage::ImageRgba8(img);
+        // offset_x=0.1 → dx = 0.1 * 32 = 3px 右シフト → 幽霊は左の白領域から来る
+        let out = diplopia(input, 1.0, 0.1, 0.0, 1.0).unwrap();
+        let out_px_val = out.to_rgba8().get_pixel(check_x, check_y)[0];
+        assert!(
+            out_px_val > orig_px,
+            "diplopia should brighten via ghost: orig={orig_px}, out={out_px_val}"
+        );
+    }
+
+    #[test]
+    fn diplopia_strength_zero_is_identity() {
+        let size = 32_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 5) as u8, (y * 7) as u8, 128, 255]);
+        }
+        let orig = img.clone().into_raw();
+        let out = diplopia(DynamicImage::ImageRgba8(img), 0.0, 0.1, 0.1, 0.7).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        let max_err = orig.iter().zip(out_raw.iter())
+            .map(|(&a, &b)| (a as i32 - b as i32).unsigned_abs())
+            .max()
+            .unwrap_or(0);
+        assert!(max_err <= 1, "strength=0 should be identity, max_err={max_err}");
+    }
+
+    #[test]
+    fn nystagmus_blurs_image() {
+        let size = 32_u32;
+        let input = center_white_dot(size);
+        let cx = size / 2;
+        let cy = size / 2;
+        let orig_center = input.to_rgba8().get_pixel(cx, cy)[0];
+
+        let out = nystagmus(input, 1.0, 0.1, 0.0).unwrap();
+        let out_center = out.to_rgba8().get_pixel(cx, cy)[0];
+        assert!(
+            out_center < orig_center,
+            "nystagmus should blur white dot: orig={orig_center}, out={out_center}"
+        );
+    }
+
+    #[test]
+    fn nystagmus_zero_amplitude_is_identity() {
+        let size = 32_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 6) as u8, (y * 8) as u8, 100, 255]);
+        }
+        let orig = img.clone().into_raw();
+        let out = nystagmus(DynamicImage::ImageRgba8(img), 1.0, 0.0, 0.0).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        let max_err = orig.iter().zip(out_raw.iter())
+            .map(|(&a, &b)| (a as i32 - b as i32).unsigned_abs())
+            .max()
+            .unwrap_or(0);
+        assert!(max_err <= 1, "amplitude=0 should be identity, max_err={max_err}");
+    }
+
+    #[test]
+    fn starbursts_brightens_near_bright_pixels() {
+        let size = 32_u32;
+        let mut img = RgbaImage::from_pixel(size, size, Rgba([0, 0, 0, 255]));
+        img.put_pixel(size / 2, size / 2, Rgba([255, 255, 255, 255]));
+
+        // 中央から 3px 離れた画素の元の値
+        let nearby_x = size / 2 + 3;
+        let nearby_y = size / 2;
+        let orig_nearby = img.get_pixel(nearby_x, nearby_y)[0];
+
+        let out = starbursts(DynamicImage::ImageRgba8(img), 1.0, 8, 0.2, 0.5).unwrap();
+        let out_nearby = out.to_rgba8().get_pixel(nearby_x, nearby_y)[0];
+
+        assert!(
+            out_nearby > orig_nearby,
+            "starbursts should brighten pixels near bright source: orig={orig_nearby}, out={out_nearby}"
+        );
+    }
+
+    #[test]
+    fn starbursts_strength_zero_is_identity() {
+        let size = 32_u32;
+        let mut img = RgbaImage::from_pixel(size, size, Rgba([0, 0, 0, 255]));
+        img.put_pixel(size / 2, size / 2, Rgba([255, 255, 255, 255]));
+        let orig = img.clone().into_raw();
+        let out = starbursts(DynamicImage::ImageRgba8(img), 0.0, 6, 0.1, 0.5).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        let max_err = orig.iter().zip(out_raw.iter())
+            .map(|(&a, &b)| (a as i32 - b as i32).unsigned_abs())
+            .max()
+            .unwrap_or(0);
+        assert!(max_err <= 1, "strength=0 should be identity, max_err={max_err}");
     }
 }


### PR DESCRIPTION
## 関連 Issue
closes #29

## 変更内容

### 新フィルタ 3 種

| フィルタ | 説明 | CLI |
|---|---|---|
| `diplopia` | 複視（幽霊像の alpha blend） | `--filter diplopia --offset-x 0.02 --offset-y 0.01 --ghost-strength 0.7` |
| `nystagmus` | 眼振（方向性 motion blur） | `--filter nystagmus --amplitude 0.03 --direction-deg 0` |
| `starbursts` | スターバースト（輝度閾値→放射状光芒） | `--filter starbursts --num-rays 6 --ray-length 0.1 --threshold 0.8` |

### 追加ファイル
- `crates/core/src/shaders/diplopia.frag`
- `crates/core/src/shaders/nystagmus.frag`
- `crates/core/src/shaders/starbursts.frag`

### 変更ファイル
- `crates/core/src/vision.rs`: 3 関数 + テスト 6 件追加
- `crates/core/src/shaders.rs`: uniform 構造体 3 種 + glsl()/uniforms() 関数追加
- `crates/core/src/lib.rs`: Filter enum + FilterStep フィールド追加
- `crates/core/src/pipeline.rs`: FilterStep::apply() に 3 フィルタ追加
- `crates/cli/src/main.rs`: Filter enum + CLI オプション 8 個追加

## テスト
164 → 170 件 (+6)、全 183 tests 通過（lib + shader_equivalence 含む）