### PR TITLE
fix: #31/#32 レビューフォローアップ（RunError整理・コメント補足）

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -309,6 +309,10 @@ enum RunError {
 
     #[error("{0}")]
     PortraitError(String),
+
+    /// --input が未指定で --mpo / --portrait も指定されていない
+    #[error("{0}")]
+    InputRequired(String),
 }
 
 fn main() -> ExitCode {
@@ -327,8 +331,16 @@ fn main() -> ExitCode {
             eprintln!("{msg}");
             ExitCode::FAILURE
         }
+        Err(err @ RunError::MpoRead { .. }) => {
+            eprintln!("{err}");
+            ExitCode::FAILURE
+        }
         Err(err @ RunError::PortraitRead { .. }) => {
             eprintln!("{err}");
+            ExitCode::FAILURE
+        }
+        Err(RunError::InputRequired(msg)) => {
+            eprintln!("{msg}");
             ExitCode::FAILURE
         }
         Err(RunError::NotImplemented(msg)) => {
@@ -430,7 +442,7 @@ fn run(cli: Cli) -> Result<(), RunError> {
 
     // --mpo なし・--portrait なし → --input が必須
     let input_path = cli.input.ok_or_else(|| {
-        RunError::MpoError(
+        RunError::InputRequired(
             "sensus: --input is required when --mpo and --portrait are not specified".to_string(),
         )
     })?;

--- a/crates/core/src/stereo.rs
+++ b/crates/core/src/stereo.rs
@@ -117,6 +117,9 @@ pub fn read_xmp_depth(data: &[u8]) -> Result<DynamicImage> {
     let mut i = 2usize; // SOI (FF D8) をスキップ
     while i + 4 <= data.len() {
         if data[i] != 0xFF {
+            // JPEG マーカーは必ず 0xFF で始まる。
+            // SOS (0xFFDA) 以降はエントロピー符号化データが続くため
+            // マーカー形式ではなくなる。その時点で APP1 探索を打ち切る。
             break;
         }
         let marker = data[i + 1];


### PR DESCRIPTION
## 変更内容

- `RunError::InputRequired` を追加し、`--input` 未指定時のエラーを `MpoError` から独立した型に変更
- `main()` の match アームで `MpoRead` に専用アームを追加し `PortraitRead` との非対称を解消
- `read_xmp_depth` の `data[i] != 0xFF` break に JPEG SOS 以降の走査打ち切りの意図をコメントで明示