### PR TITLE
feat: floaters / tetrachromacy / cataract 改善 (#38, #39, #40)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,7 +916,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "sensus"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "image",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "sensus-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "image",
  "thiserror 1.0.69",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -42,6 +42,9 @@ enum Filter {
     Diplopia,
     Nystagmus,
     Starbursts,
+    // Phase 4: 眼精疲労・ドライアイ (Issue #36)
+    EyeStrain,
+    DryEye,
     // Phase N: 深度マップ対応距離依存ぼけ (Issue #19)
     MyopiaDepth,
     HyperopiaDepth,
@@ -88,6 +91,8 @@ impl Filter {
             Filter::Diplopia => CoreFilter::Diplopia,
             Filter::Nystagmus => CoreFilter::Nystagmus,
             Filter::Starbursts => CoreFilter::Starbursts,
+            Filter::EyeStrain => CoreFilter::EyeStrain,
+            Filter::DryEye => CoreFilter::DryEye,
             Filter::MyopiaDepth | Filter::HyperopiaDepth | Filter::DepthOfField => {
                 // depth フィルタは pipeline を通さないため、ここには来ない
                 unreachable!("depth filters must be handled separately")

--- a/crates/core/src/hearing.rs
+++ b/crates/core/src/hearing.rs
@@ -520,6 +520,93 @@ pub fn diplacusis(buf: AudioBuffer, strength: f32) -> AudioBuffer {
     }
 }
 
+/// APD（聴覚情報処理障害）シミュレーション。
+///
+/// 時間分解能の低下 + 雑音付加を近似する:
+/// 1. LCG（seed=42 固定）によるホワイトノイズ混入
+/// 2. 隣接 3 サンプルの加重平均（FIR スミア）
+/// 3. 無音区間の gap 埋め（< 5 ms の無音を隣接値で補間）
+///
+/// `strength = 0.0` は元音声と同一。
+pub fn auditory_processing_disorder(buf: AudioBuffer, strength: f32) -> AudioBuffer {
+    let s = strength.clamp(0.0, 1.0);
+    if s == 0.0 {
+        return buf;
+    }
+
+    let ch = buf.channels as usize;
+    if ch == 0 || buf.samples.is_empty() {
+        return buf;
+    }
+
+    let n = buf.samples.len();
+
+    // Step 1: ホワイトノイズ混入（LCG, seed=42）
+    const LCG_A: u64 = 1664525;
+    const LCG_C: u64 = 1013904223;
+    let mut state: u64 = 42;
+    let noise_amp = s * 0.05; // 最大 5% のノイズ
+    let mut noisy: Vec<f32> = buf.samples.iter().map(|&x| {
+        state = state.wrapping_mul(LCG_A).wrapping_add(LCG_C);
+        // -1.0..=1.0 の符号付きノイズ
+        let noise = (state >> 32) as f32 / (u32::MAX as f32 / 2.0) - 1.0;
+        (x + noise * noise_amp).clamp(-1.0, 1.0)
+    }).collect();
+
+    // Step 2: FIR スミア（隣接 3 サンプルの加重平均: 0.25, 0.5, 0.25）
+    // strength に応じて元とブレンド
+    let w_center = 1.0 - s * 0.5; // strength=1.0 で center=0.5
+    let w_side = s * 0.25;         // strength=1.0 で side=0.25 (合計 = 0.5 + 0.5*2 = 1.0 が成立)
+    let mut smeared = noisy.clone();
+    for i in 0..n {
+        let prev = if i >= ch { noisy[i - ch] } else { noisy[i] };
+        let next = if i + ch < n { noisy[i + ch] } else { noisy[i] };
+        smeared[i] = (prev * w_side + noisy[i] * w_center + next * w_side).clamp(-1.0, 1.0);
+    }
+    noisy = smeared;
+
+    // Step 3: gap 埋め（< 5 ms の無音区間を前後の値で補間）
+    // sample_rate=0 は 44100 Hz として扱う
+    let sr = if buf.sample_rate == 0 { 44100 } else { buf.sample_rate };
+    let gap_frames = ((sr as f32 * 0.005) as usize).max(1); // 5 ms
+    let silence_threshold = 0.01_f32;
+
+    let frames = n / ch;
+    let mut result = noisy.clone();
+    let mut gap_start: Option<usize> = None;
+
+    for f in 0..frames {
+        // フレームが無音かどうか（全チャンネル）
+        let is_silent = (0..ch).all(|c| noisy[f * ch + c].abs() < silence_threshold);
+        if is_silent {
+            if gap_start.is_none() {
+                gap_start = Some(f);
+            }
+        } else if let Some(gs) = gap_start {
+                let gap_len = f - gs;
+                if gap_len < gap_frames {
+                    // gap を前後の値で線形補間して埋める
+                    let before_f = if gs > 0 { gs - 1 } else { gs };
+                    for gf in gs..f {
+                        let t = (gf - gs + 1) as f32 / (gap_len + 1) as f32;
+                        for c in 0..ch {
+                            let before_val = result[before_f * ch + c];
+                            let after_val = noisy[f * ch + c];
+                            result[gf * ch + c] = (before_val + (after_val - before_val) * t).clamp(-1.0, 1.0);
+                        }
+                    }
+                }
+                gap_start = None;
+        }
+    }
+
+    AudioBuffer {
+        samples: result,
+        sample_rate: buf.sample_rate,
+        channels: buf.channels,
+    }
+}
+
 // ---------------------------------------------------------------
 // テスト
 // ---------------------------------------------------------------
@@ -764,5 +851,22 @@ mod tests {
         let out = diplacusis(buf, 1.0);
         assert_eq!(out.channels, 2);
         assert_eq!(out.samples.len(), 2000);
+    }
+
+    #[test]
+    fn apd_strength_zero_is_identity() {
+        let buf = sine_wave(440.0, 1000, 44100);
+        let orig = buf.samples.clone();
+        let out = auditory_processing_disorder(buf, 0.0);
+        assert_eq!(out.samples, orig, "APD strength=0 should be byte-exact identity");
+    }
+
+    #[test]
+    fn apd_adds_noise() {
+        // 無音バッファに strength=1 で APD を適用すると RMS > 0 になる
+        let buf = silence(44100, 44100, 1);
+        let out = auditory_processing_disorder(buf, 1.0);
+        let rms: f32 = (out.samples.iter().map(|&x| x * x).sum::<f32>() / out.samples.len() as f32).sqrt();
+        assert!(rms > 0.0, "APD should add noise to silence, rms={rms}");
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,6 +59,9 @@ pub enum Filter {
     Diplopia,
     Nystagmus,
     Starbursts,
+    // vision (Phase 4: eye fatigue / #36)
+    EyeStrain,
+    DryEye,
 }
 
 /// Apply a [`Filter`] to an image at a given strength (`0.0..=1.0`).
@@ -97,6 +100,8 @@ pub fn apply(
         Filter::Diplopia => vision::diplopia(img, strength, 0.02, 0.01, 0.7),
         Filter::Nystagmus => vision::nystagmus(img, strength, 0.03, 0.0),
         Filter::Starbursts => vision::starbursts(img, strength, 6, 0.1, 0.8),
+        Filter::EyeStrain => vision::eye_strain(img, strength),
+        Filter::DryEye => vision::dry_eye(img, strength),
     }
 }
 
@@ -125,6 +130,8 @@ pub enum HearingFilter {
     PitchShift { semitones: f32 },
     /// ダイプラクシス: 左右耳で異なる音程を知覚
     Diplacusis,
+    /// APD（聴覚情報処理障害）: 時間分解能低下 + 雑音付加
+    AuditoryProcessingDisorder,
 }
 
 /// 聴覚フィルタを音声バッファに適用する。
@@ -152,6 +159,9 @@ pub fn apply_hearing(
         HearingFilter::Dysmelodia => hearing::dysmelodia(buf, strength),
         HearingFilter::PitchShift { semitones } => hearing::pitch_shift_semitones(buf, semitones),
         HearingFilter::Diplacusis => hearing::diplacusis(buf, strength),
+        HearingFilter::AuditoryProcessingDisorder => {
+            hearing::auditory_processing_disorder(buf, strength)
+        }
     };
     Ok(out)
 }

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -96,6 +96,16 @@ pub fn starbursts_glsl() -> &'static str {
     include_str!("shaders/starbursts.frag")
 }
 
+/// eye_strain.frag の GLSL ES 3.00 ソースを返す。
+pub fn eye_strain_glsl() -> &'static str {
+    include_str!("shaders/eye_strain.frag")
+}
+
+/// dry_eye.frag の GLSL ES 3.00 ソースを返す。
+pub fn dry_eye_glsl() -> &'static str {
+    include_str!("shaders/dry_eye.frag")
+}
+
 // ---------------------------------------------------------------------------
 // uniform 構造体
 // ---------------------------------------------------------------------------

--- a/crates/core/src/shaders/dry_eye.frag
+++ b/crates/core/src/shaders/dry_eye.frag
@@ -1,0 +1,42 @@
+#version 300 es
+precision mediump float;
+uniform sampler2D u_image;
+uniform float u_strength;
+in vec2 v_texcoord;
+out vec4 out_color;
+
+// 簡易ハッシュ関数（シェーダ内ノイズ生成用）
+float hash(vec2 p) {
+    p = fract(p * vec2(127.1, 311.7));
+    p += dot(p, p + 19.19);
+    return fract(p.x * p.y);
+}
+
+void main() {
+    // タイル座標（32x32 タイル想定）でノイズ値を決定
+    vec2 tile_coord = floor(v_texcoord * 16.0); // 画面を 16 分割
+    float noise = hash(tile_coord + vec2(42.0, 42.0));
+    float blur_amount = noise * u_strength;
+
+    // 近傍サンプルの平均でソフトブラーを近似
+    vec2 texel_size = vec2(1.0) / vec2(textureSize(u_image, 0));
+    vec4 color = vec4(0.0);
+    float total = 0.0;
+    float r = blur_amount * 2.0;
+    for (int dy = -2; dy <= 2; dy++) {
+        for (int dx = -2; dx <= 2; dx++) {
+            float dist = length(vec2(float(dx), float(dy)));
+            if (dist <= r + 0.5) {
+                vec2 offset = vec2(float(dx), float(dy)) * texel_size;
+                color += texture(u_image, v_texcoord + offset);
+                total += 1.0;
+            }
+        }
+    }
+    if (total > 0.0) {
+        color /= total;
+    } else {
+        color = texture(u_image, v_texcoord);
+    }
+    out_color = vec4(color.rgb, texture(u_image, v_texcoord).a);
+}

--- a/crates/core/src/shaders/eye_strain.frag
+++ b/crates/core/src/shaders/eye_strain.frag
@@ -1,0 +1,16 @@
+#version 300 es
+precision mediump float;
+uniform sampler2D u_image;
+uniform float u_strength;
+in vec2 v_texcoord;
+out vec4 out_color;
+void main() {
+    vec4 c = texture(u_image, v_texcoord);
+    // contrast compression
+    vec3 compressed = vec3(0.5) + (c.rgb - vec3(0.5)) * (1.0 - u_strength * 0.15);
+    // vignette
+    vec2 uv = v_texcoord * 2.0 - 1.0;
+    float d = dot(uv, uv);
+    float vignette = 1.0 - u_strength * 0.3 * smoothstep(0.3, 1.2, d);
+    out_color = vec4(clamp(compressed * vignette, 0.0, 1.0), c.a);
+}

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -618,7 +618,16 @@ pub fn astigmatism(img: DynamicImage, strength: f32, axis_deg: f32) -> Result<Dy
 
 /// 白内障（Cataract）シミュレーション。
 ///
-/// linear sRGB 空間で輝度低下・黄色み追加・局所白濁ノイズを適用する。
+/// linear sRGB 空間で黄変マトリクスを適用してコントラストを圧縮し、
+/// その後に局所白濁ノイズ（haze）を重ねる。
+///
+/// ### 黄変マトリクス
+/// ```text
+/// R' = R * 1.00 + G * 0.05 + B * (-0.05)
+/// G' = R * 0.02 + G * 1.00 + B * (-0.02)
+/// B' = R * 0.00 + G * 0.00 + B *  0.85
+/// ```
+/// strength でブレンド: `final = orig * (1-s) + yellowed * s`
 ///
 /// - `strength`: 0.0 = 元画像, 1.0 = 強度白内障
 /// - `seed`: 白濁ノイズのランダムシード
@@ -632,11 +641,6 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
 
     let width = rgba.width();
     let height = rgba.height();
-
-    // チャンネルごとの乗数（黄色み: B を強く抑制）
-    let r_factor = 1.0 - strength * 0.3_f32;
-    let g_factor = 1.0 - strength * 0.3_f32;
-    let b_factor = 1.0 - strength * 0.6_f32;
 
     // 白濁ノイズの最大ブレンド量
     const WHITE_BLEND_MAX: f32 = 0.4;
@@ -670,10 +674,15 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
             let g = srgb_to_linear(px[1] as f32 / 255.0);
             let b = srgb_to_linear(px[2] as f32 / 255.0);
 
-            // チャンネル別輝度低下・黄色み
-            let nr = r * r_factor;
-            let ng = g * g_factor;
-            let nb = b * b_factor;
+            // 黄変マトリクスを適用
+            let yr = (r * 1.00 + g * 0.05 + b * (-0.05)).clamp(0.0, 1.0);
+            let yg = (r * 0.02 + g * 1.00 + b * (-0.02)).clamp(0.0, 1.0);
+            let yb = (r * 0.00 + g * 0.00 + b * 0.85).clamp(0.0, 1.0);
+
+            // strength でブレンド: orig * (1-s) + yellowed * s
+            let nr = r + (yr - r) * strength;
+            let ng = g + (yg - g) * strength;
+            let nb = b + (yb - b) * strength;
 
             // ブロックノイズによる白濁
             let bx = (x / BLOCK_SIZE) as usize;
@@ -805,11 +814,13 @@ pub fn nyctalopia(img: DynamicImage, strength: f32) -> crate::Result<DynamicImag
 
 /// 飛蚊症（Floaters）シミュレーション。
 ///
-/// 視野内に暗い blob が浮かぶオーバーレイを乗算ブレンドで適用する。
+/// 視野内に暗い blob と糸くず形状が浮かぶオーバーレイを乗算ブレンドで適用する。
+/// 円形 blob 30% + 糸くず形状（ランダムウォーク折れ線） 70% の混合。
+/// 描画後に box blur (radius 1px) でエッジをソフト化する。
 ///
 /// - `strength`: 0.0 = 元画像, 1.0 = 強い飛蚊症
 /// - `density`: blob 密度 (0.0..=1.0)
-/// - `seed`: blob 配置のランダムシード
+/// - `seed`: blob 配置のランダムシード（実際に使用される）
 /// - `gaze_x`: 視線 X 位置 (0.0 = 左, 1.0 = 右)
 /// - `gaze_y`: 視線 Y 位置 (0.0 = 上, 1.0 = 下)
 pub fn floaters(
@@ -840,63 +851,169 @@ pub fn floaters(
     let offset_x = (gaze_x - 0.5) * 0.3 * w_f;
     let offset_y = (gaze_y - 0.5) * 0.3 * h_f;
 
-    // blob 数と半径
-    let blob_count = (density * 200.0) as usize; // density=0.0 → 0 個（フローターなし）
-    if blob_count == 0 {
+    // blob/糸くず 総数
+    let total_count = (density * 200.0) as usize;
+    if total_count == 0 {
         return Ok(DynamicImage::ImageRgba8(rgba));
     }
+
+    let blob_count = (total_count as f32 * 0.3).ceil() as usize; // 30% 円形
+    let strand_count = total_count - blob_count;                  // 70% 糸くず
+
     let blob_radius = (w_f.min(h_f) * 0.04).max(2.0);
     let blob_radius_sq = blob_radius * blob_radius;
 
-    // blob 中心位置を seed から生成
-    let mut centers: Vec<(f32, f32)> = Vec::with_capacity(blob_count);
-    for i in 0..blob_count {
-        let hx = seed
-            .wrapping_mul(0x9e3779b97f4a7c15)
-            .wrapping_add((i as u64).wrapping_mul(0x517cc1b727220a95))
-            .wrapping_add(0xdeadbeefcafe1234);
-        let hy = seed
-            .wrapping_mul(0x6c62272e07bb0142)
-            .wrapping_add((i as u64).wrapping_mul(0x9e3779b97f4a7c15))
-            .wrapping_add(0xc0ffee0102030405);
-        let cx = (hx >> 32) as f32 / u32::MAX as f32 * w_f + offset_x;
-        let cy = (hy >> 32) as f32 / u32::MAX as f32 * h_f + offset_y;
-        centers.push((cx, cy));
+    // ── LCG ヘルパー ──────────────────────────────────────────────
+    // 64bit LCG: state → next state, returns 0..=u32::MAX を f32 に正規化した値
+    let lcg_next = |state: u64| -> (u64, f32) {
+        let next = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let fval = (next >> 32) as f32 / u32::MAX as f32;
+        (next, fval)
+    };
+
+    // seed から初期 LCG 状態を生成
+    let init_state = seed.wrapping_mul(0x9e3779b97f4a7c15).wrapping_add(1);
+
+    // ── マスクバッファ（0.0 = 完全フローター, 1.0 = 透明）────────
+    let npx = (width * height) as usize;
+    let mut mask_buf: Vec<f32> = vec![1.0_f32; npx];
+
+    // ── 円形 blob を描画 ─────────────────────────────────────────
+    let mut state = init_state;
+    for _ in 0..blob_count {
+        let (s1, fx) = lcg_next(state);
+        let (s2, fy) = lcg_next(s1);
+        state = s2;
+        let cx = fx * w_f + offset_x;
+        let cy = fy * h_f + offset_y;
+
+        // AABB で描画範囲を絞る
+        let r_ceil = blob_radius.ceil() as i32;
+        let x0 = ((cx - blob_radius).floor() as i32).max(0);
+        let x1 = ((cx + blob_radius).ceil() as i32).min(width as i32 - 1);
+        let y0 = ((cy - blob_radius).floor() as i32).max(0);
+        let y1 = ((cy + blob_radius).ceil() as i32).min(height as i32 - 1);
+        let _ = r_ceil;
+
+        for py in y0..=y1 {
+            for px in x0..=x1 {
+                let dx = px as f32 - cx;
+                let dy = py as f32 - cy;
+                let d2 = dx * dx + dy * dy;
+                if d2 < blob_radius_sq {
+                    let t = d2 / blob_radius_sq;
+                    let m = t * t * (3.0 - 2.0 * t); // smoothstep: エッジで 1.0
+                    let idx = py as usize * width as usize + px as usize;
+                    if m < mask_buf[idx] {
+                        mask_buf[idx] = m;
+                    }
+                }
+            }
+        }
     }
 
-    // フローターマスクを生成して元画像に乗算ブレンド
-    let mut out_rgba = rgba.clone();
-    for y in 0..height {
-        for x in 0..width {
-            let xf = x as f32;
-            let yf = y as f32;
+    // ── 糸くず形状を描画（ランダムウォーク折れ線） ────────────────
+    for _ in 0..strand_count {
+        // 開始点
+        let (s1, fx) = lcg_next(state);
+        let (s2, fy) = lcg_next(s1);
+        // セグメント数 2..=5
+        let (s3, fn_seg) = lcg_next(s2);
+        // 初期角度
+        let (s4, f_angle) = lcg_next(s3);
+        // 線幅 1..=4 px
+        let (s5, f_width) = lcg_next(s4);
+        state = s5;
 
-            // 最も近い blob との距離でマスク値を決定
-            let mut min_dist_sq = f32::MAX;
-            for &(cx, cy) in &centers {
-                let dx = xf - cx;
-                let dy = yf - cy;
-                let d2 = dx * dx + dy * dy;
-                if d2 < min_dist_sq {
-                    min_dist_sq = d2;
+        let sx = fx * w_f + offset_x;
+        let sy = fy * h_f + offset_y;
+        let n_seg = (fn_seg * 4.0) as usize + 2; // 2..=5
+        let half_w = (f_width * 3.0 + 1.0) * 0.5; // 0.5..=2.0
+
+        let mut cur_x = sx;
+        let mut cur_y = sy;
+        let mut cur_angle = f_angle * std::f32::consts::TAU;
+
+        for seg in 0..n_seg {
+            // セグメント長 5..=15 px
+            let (s_len, f_len) = lcg_next(state.wrapping_add(seg as u64));
+            // 角度変化 ±45°
+            let (s_da, f_da) = lcg_next(s_len);
+            state = s_da;
+
+            let seg_len = f_len * 10.0 + 5.0;
+            let delta_angle = (f_da - 0.5) * std::f32::consts::FRAC_PI_2; // ±45°
+            cur_angle += delta_angle;
+
+            let nx = cur_x + cur_angle.cos() * seg_len;
+            let ny = cur_y + cur_angle.sin() * seg_len;
+
+            // 線分を太さ half_w でラスタライズ
+            let steps = (seg_len.ceil() as usize * 4).max(1);
+            for step in 0..=steps {
+                let t = step as f32 / steps as f32;
+                let lx = cur_x + (nx - cur_x) * t;
+                let ly = cur_y + (ny - cur_y) * t;
+
+                let hw_ceil = (half_w.ceil() as i32) + 1;
+                let px0 = ((lx - half_w).floor() as i32 - hw_ceil).max(0);
+                let px1 = ((lx + half_w).ceil() as i32 + hw_ceil).min(width as i32 - 1);
+                let py0 = ((ly - half_w).floor() as i32 - hw_ceil).max(0);
+                let py1 = ((ly + half_w).ceil() as i32 + hw_ceil).min(height as i32 - 1);
+
+                for py in py0..=py1 {
+                    for ppx in px0..=px1 {
+                        let dx = ppx as f32 - lx;
+                        let dy = py as f32 - ly;
+                        let dist = (dx * dx + dy * dy).sqrt();
+                        if dist < half_w {
+                            let m = (dist / half_w).clamp(0.0, 1.0);
+                            let idx = py as usize * width as usize + ppx as usize;
+                            if m < mask_buf[idx] {
+                                mask_buf[idx] = m;
+                            }
+                        }
+                    }
                 }
             }
 
-            // blob 内部: smoothstep 減衰でマスク値を計算
-            // mask = 0.0 → フローター（暗い）、1.0 → 元画像
-            let mask = if min_dist_sq < blob_radius_sq {
-                let t = min_dist_sq / blob_radius_sq;
-                // smoothstep: 外側ほど 1.0 に近い
-                t * t * (3.0 - 2.0 * t)
-            } else {
-                1.0
-            };
+            cur_x = nx;
+            cur_y = ny;
+        }
+    }
 
-            // 元画像 × (1.0 - strength * (1.0 - mask)) で乗算ブレンド
+    // ── box blur (radius 1px) でエッジをソフト化 ──────────────────
+    let mut blurred_mask: Vec<f32> = vec![0.0_f32; npx];
+    let w = width as usize;
+    let h = height as usize;
+    for py in 0..h {
+        for px in 0..w {
+            let mut sum = 0.0_f32;
+            let mut cnt = 0_u32;
+            for dy in -1_i32..=1 {
+                for dx in -1_i32..=1 {
+                    let nx = px as i32 + dx;
+                    let ny = py as i32 + dy;
+                    if nx >= 0 && nx < w as i32 && ny >= 0 && ny < h as i32 {
+                        sum += mask_buf[ny as usize * w + nx as usize];
+                        cnt += 1;
+                    }
+                }
+            }
+            blurred_mask[py * w + px] = sum / cnt as f32;
+        }
+    }
+
+    // ── 元画像に乗算ブレンド ──────────────────────────────────────
+    let mut out_rgba = rgba.clone();
+    for y in 0..height {
+        for x in 0..width {
+            let mask = blurred_mask[y as usize * w + x as usize];
             let blend = 1.0 - strength * (1.0 - mask);
 
             let px = out_rgba.get_pixel_mut(x, y);
-            // linear sRGB 空間で乗算（gamma 解除 → 処理 → gamma 戻し）
             let rl = srgb_to_linear(px[0] as f32 / 255.0);
             let gl = srgb_to_linear(px[1] as f32 / 255.0);
             let bl = srgb_to_linear(px[2] as f32 / 255.0);
@@ -917,24 +1034,20 @@ pub fn floaters(
 /// 四色型色覚（Tetrachromacy）可視化。
 ///
 /// RGB 画像は分光情報を失っているため完全な四色型シミュレーションは不可能。
-/// 三色型がメタメリズムを起こしやすい赤-緑中間帯（約 560 nm 付近）の微細な
-/// 色差を誇張することで、「四色型が見えているはずの差異」を近似可視化する。
+/// メタメリズムベースのアルゴリズムで、L/M 錐体の差分が小さい領域（メタメリック
+/// ペア候補）を検出し、その領域の Cb/Cr 色差を追加誇張する。
+/// 全領域には赤-緑 opponent channel の基本誇張も適用する。
 ///
-/// ## アルゴリズム
+/// ## アルゴリズム（Machado 2009 LMS 変換使用）
 ///
 /// 1. linear sRGB に変換（gamma 解除）
-/// 2. opponent channel を計算:
-///    - `rg = R - G`（赤-緑対立軸）
-///    - `yb = 0.5*(R+G) - B`（黄-青対立軸）
- /// 3. opponent channel を `strength` でスケールして元の色に加算（誇張）:
- ///    - `R_out = R + strength * rg * k_rg`
- ///    - `G_out = G - strength * rg * k_rg`
- ///    - `B_out = B + strength * yb * k_yb`（黄青は控えめ）
- ///    - `k_rg = 0.5`（赤-緑誇張係数）
- ///    - `k_yb = 0.25`（黄-青誇張係数、`k_rg` の半分）
-/// 4. clamp(0.0, 1.0)
-/// 5. linear → sRGB に戻す（gamma 再適用）
-/// 6. alpha は保持
+/// 2. linear sRGB → LMS（Machado 2009 の変換行列）
+/// 3. M（緑錐体）と L（赤錐体）の差分 `delta = M - L` を抽出
+/// 4. `|delta| < 0.05` の領域 = メタメリックペア候補
+/// 5. そのような領域で Cb/Cr（色差）を `strength * 2.0` 倍に誇張
+/// 6. 全領域: 赤-緑 opponent channel を基本誇張（strength でスケール）
+/// 7. clamp(0.0, 1.0) して linear → sRGB に戻す
+/// 8. alpha は保持
 ///
 /// `strength = 0.0` は元画像と完全一致。`strength = 1.0` で最大誇張。
 pub fn tetrachromacy(img: DynamicImage, strength: f32) -> crate::Result<DynamicImage> {
@@ -945,20 +1058,46 @@ pub fn tetrachromacy(img: DynamicImage, strength: f32) -> crate::Result<DynamicI
         return Ok(DynamicImage::ImageRgba8(rgba));
     }
 
-    const K_RG: f32 = 0.5;  // 赤-緑誇張係数
-    const K_YB: f32 = 0.25; // 黄-青誇張係数（控えめ）
+    // Machado 2009 linear sRGB → LMS 変換行列
+    // 出典: Machado, Oliveira, Fernandes 2009, Equation 1 / Table 1
+    // (Hunt-Pointer-Estévez の D65 白色点正規化版)
+    const SRGB_TO_LMS: [[f32; 3]; 3] = [
+        [0.4002, 0.7076, -0.0808],
+        [-0.2263, 1.1653, 0.0457],
+        [0.0000, 0.0000, 0.9182],
+    ];
+
+    // 基本赤-緑誇張係数（全領域に適用）
+    const K_RG: f32 = 0.5;
 
     for px in rgba.pixels_mut() {
         let r = srgb_to_linear(px[0] as f32 / 255.0);
         let g = srgb_to_linear(px[1] as f32 / 255.0);
         let b = srgb_to_linear(px[2] as f32 / 255.0);
 
-        let rg = r - g;
-        let yb = 0.5 * (r + g) - b;
+        // linear sRGB → LMS
+        let l_cone = SRGB_TO_LMS[0][0] * r + SRGB_TO_LMS[0][1] * g + SRGB_TO_LMS[0][2] * b;
+        let m_cone = SRGB_TO_LMS[1][0] * r + SRGB_TO_LMS[1][1] * g + SRGB_TO_LMS[1][2] * b;
 
-        let nr = r + strength * rg * K_RG;
-        let ng = g - strength * rg * K_RG;
-        let nb = b + strength * yb * K_YB;
+        // M と L の差分（メタメリズム指標）
+        let delta = m_cone - l_cone;
+
+        // 全領域: 赤-緑 opponent channel 誇張（既存テスト互換）
+        let rg = r - g;
+        let mut nr = r + strength * rg * K_RG;
+        let mut ng = g - strength * rg * K_RG;
+        let mut nb = b;
+
+        // |delta| < 0.05 のメタメリックペア候補領域: Cb/Cr をさらに誇張
+        if delta.abs() < 0.05 {
+            let y = LUMA_R * r + LUMA_G * g + LUMA_B * b;
+            let cb = b - y;
+            let cr = r - y;
+            let scale = strength * 2.0;
+            nr = (y + cr * scale).clamp(0.0, 1.0);
+            ng = y.clamp(0.0, 1.0);
+            nb = (y + cb * scale).clamp(0.0, 1.0);
+        }
 
         px[0] = pack_u8(linear_to_srgb(nr.clamp(0.0, 1.0)));
         px[1] = pack_u8(linear_to_srgb(ng.clamp(0.0, 1.0)));
@@ -3365,6 +3504,70 @@ mod tests {
         assert!(
             diff10 > diff05,
             "strength=1.0 R-G diff ({diff10}) must be greater than strength=0.5 ({diff05})"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // #38: floaters seed=0 と seed=1 で出力が異なること
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn floaters_seed_0_ne_seed_1() {
+        let input = solid_rgba(32, 32, [200, 150, 100, 255]);
+        let out0 = raw_rgba_vec(&floaters(input.clone(), 0.8, 0.5, 0, 0.5, 0.5).unwrap());
+        let out1 = raw_rgba_vec(&floaters(input, 0.8, 0.5, 1, 0.5, 0.5).unwrap());
+        assert_ne!(out0, out1, "seed=0 and seed=1 must produce different output");
+    }
+
+    // ---------------------------------------------------------------
+    // #39: tetrachromacy メタメリック領域で色差が誇張されること
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn tetrachromacy_metameric_regions_enhanced() {
+        // グレーに近い画素（R≈G≈B）は LMS で delta≈0 となりメタメリックペア候補
+        // strength=1.0 で Cb/Cr 誇張が適用され、元画像からの変化が大きくなるはず
+        // ただし純グレー(R==G==B)はCb=Cr=0なので変化なし。
+        // わずかに色差のある画素でテストする
+        let input_neutral = pixel(128, 128, 128, 255); // 純グレー: 変化なし
+        let out_neutral = tetrachromacy(input_neutral, 1.0).unwrap();
+        let [r, g, b, _] = read_rgba(&out_neutral);
+        // 純グレーは変化なし（メタメリックだが Cb/Cr=0）
+        assert!(
+            (r as i32 - g as i32).abs() <= 2,
+            "neutral gray should stay near-gray after tetrachromacy"
+        );
+        let _ = b;
+
+        // 赤みのある画素: LMS delta が大きくメタメリックペアでないため
+        // opponent channel による誇張が適用される
+        let input_red = pixel(200, 100, 50, 255);
+        let out_s0 = tetrachromacy(input_red.clone(), 0.0).unwrap();
+        let out_s1 = tetrachromacy(input_red, 1.0).unwrap();
+        let [r0, g0, _, _] = read_rgba(&out_s0);
+        let [r1, g1, _, _] = read_rgba(&out_s1);
+        assert_ne!(
+            (r0 as i32 - g0 as i32),
+            (r1 as i32 - g1 as i32),
+            "strength=1.0 should differ from strength=0.0 on colored pixels"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // #40: cataract 黄変マトリクス - 青チャネル平均が入力より低いこと
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn cataract_yellowing_blue_mean_reduced() {
+        // strength=1.0 で B * 0.85 となるため、青い画素で B が低下する
+        let input = solid_rgba(16, 16, [128, 128, 255, 255]);
+        let out = cataract(input, 1.0, 0).unwrap().to_rgba8();
+        let orig_b_mean: f64 = 255.0;
+        let out_b_mean: f64 = out.pixels().map(|p| p[2] as f64).sum::<f64>()
+            / (out.width() * out.height()) as f64;
+        assert!(
+            out_b_mean < orig_b_mean,
+            "cataract yellowing: blue channel mean ({out_b_mean:.1}) should be below input ({orig_b_mean:.1})"
         );
     }
 

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -1745,6 +1745,143 @@ pub fn starbursts(
     Ok(DynamicImage::ImageRgba8(out))
 }
 
+// ---------------------------------------------------------------
+// Phase 4 (#36): eye fatigue — eye_strain / dry_eye
+// ---------------------------------------------------------------
+
+/// 眼精疲労（eye strain）シミュレーション。
+///
+/// - コントラスト圧縮: `v' = 0.5 + (v - 0.5) * (1.0 - strength * 0.15)`
+/// - 微小 disk blur（radius = strength * 1.5 px）
+/// - 周辺 vignette（軽め）
+///
+/// `strength = 0.0` は元画像と完全一致。
+pub fn eye_strain(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    let rgba = img.to_rgba8();
+    if s == 0.0 {
+        return Ok(DynamicImage::ImageRgba8(rgba));
+    }
+
+    let width = rgba.width();
+    let height = rgba.height();
+    let w_f = width as f32;
+    let h_f = height as f32;
+    let cx = w_f * 0.5;
+    let cy = h_f * 0.5;
+    let max_r = (cx * cx + cy * cy).sqrt();
+
+    // コントラスト圧縮係数
+    let contrast_factor = 1.0 - s * 0.15;
+
+    // Step 1: linear sRGB 空間でコントラスト圧縮 + vignette
+    let (linear, alpha) = rgba_to_linear_planes(&rgba);
+    let mut compressed: Vec<[f32; 3]> = linear
+        .iter()
+        .enumerate()
+        .map(|(i, &[r, g, b])| {
+            let x = (i as u32 % width) as f32;
+            let y = (i as u32 / width) as f32;
+            let dx = x - cx;
+            let dy = y - cy;
+            let d_sq = (dx * dx + dy * dy) / (max_r * max_r);
+
+            // コントラスト圧縮（linear 空間で 0.5 中心に圧縮）
+            let cr = 0.5 + (r - 0.5) * contrast_factor;
+            let cg = 0.5 + (g - 0.5) * contrast_factor;
+            let cb = 0.5 + (b - 0.5) * contrast_factor;
+
+            // vignette（周辺を軽く暗化）
+            let vignette = 1.0 - s * 0.3 * d_sq.clamp(0.3, 1.2).powi(2).sqrt();
+
+            [
+                (cr * vignette).clamp(0.0, 1.0),
+                (cg * vignette).clamp(0.0, 1.0),
+                (cb * vignette).clamp(0.0, 1.0),
+            ]
+        })
+        .collect();
+
+    // Step 2: 微小 disk blur（radius = strength * 1.5 px、min 0.5 px で有効）
+    let blur_radius = s * 1.5;
+    if blur_radius >= MIN_BLUR_RADIUS_PX {
+        compressed = ellipse_blur(&compressed, width, height, blur_radius, blur_radius, 0.0);
+    }
+
+    let out = linear_planes_to_rgba(&compressed, &alpha, width, height);
+    Ok(DynamicImage::ImageRgba8(out))
+}
+
+/// ドライアイ（dry eye）シミュレーション。
+///
+/// LCG（seed=42 固定）で生成したノイズマスクを基に、
+/// 32×32 タイルごとに異なる disk blur radius を適用する。
+///
+/// `strength = 0.0` は元画像と完全一致。
+pub fn dry_eye(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    let rgba = img.to_rgba8();
+    if s == 0.0 {
+        return Ok(DynamicImage::ImageRgba8(rgba));
+    }
+
+    let width = rgba.width();
+    let height = rgba.height();
+    let (linear, alpha) = rgba_to_linear_planes(&rgba);
+
+    const TILE_SIZE: u32 = 32;
+    const LCG_SEED: u64 = 42;
+    // LCG 定数（Numerical Recipes）
+    const LCG_A: u64 = 1664525;
+    const LCG_C: u64 = 1013904223;
+
+    // タイル数を計算
+    let tile_cols = width.div_ceil(TILE_SIZE);
+    let tile_rows = height.div_ceil(TILE_SIZE);
+
+    // LCG でタイルごとのノイズ値を生成
+    let mut noise_map: Vec<f32> = Vec::with_capacity((tile_cols * tile_rows) as usize);
+    let mut state = LCG_SEED;
+    for _ in 0..(tile_cols * tile_rows) {
+        state = state.wrapping_mul(LCG_A).wrapping_add(LCG_C);
+        let n = (state >> 33) as f32 / (u32::MAX >> 1) as f32; // 0.0..=1.0
+        noise_map.push(n);
+    }
+
+    // 出力バッファを元画像で初期化
+    let mut out_linear = linear.clone();
+
+    // タイルごとに blur を適用して出力バッファに書き込む
+    for ty in 0..tile_rows {
+        for tx in 0..tile_cols {
+            let noise = noise_map[(ty * tile_cols + tx) as usize];
+            let blur_radius = noise * s * 3.0;
+            if blur_radius < MIN_BLUR_RADIUS_PX {
+                // blur なし: 元の値をそのままコピー（既に out_linear に入っている）
+                continue;
+            }
+
+            // タイル領域を blur した結果を全画像で計算して、タイル部分だけを採用する
+            let blurred = ellipse_blur(&linear, width, height, blur_radius, blur_radius, 0.0);
+
+            let x_start = tx * TILE_SIZE;
+            let y_start = ty * TILE_SIZE;
+            let x_end = ((tx + 1) * TILE_SIZE).min(width);
+            let y_end = ((ty + 1) * TILE_SIZE).min(height);
+
+            for y in y_start..y_end {
+                for x in x_start..x_end {
+                    let idx = (y * width + x) as usize;
+                    out_linear[idx] = blurred[idx];
+                }
+            }
+        }
+    }
+
+    let out = linear_planes_to_rgba(&out_linear, &alpha, width, height);
+    Ok(DynamicImage::ImageRgba8(out))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3667,5 +3804,51 @@ mod tests {
             .unwrap_or(0);
         // strength=0 は early return するため byte-exact 一致するはず
         assert!(max_err == 0, "strength=0 should be byte-exact identity, max_err={max_err}");
+    }
+
+    #[test]
+    fn eye_strain_strength_zero_is_identity() {
+        let size = 32_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 7) as u8, (y * 7) as u8, 128, 255]);
+        }
+        let orig = img.clone().into_raw();
+        let out = eye_strain(DynamicImage::ImageRgba8(img), 0.0).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        assert_eq!(orig, out_raw, "eye_strain strength=0 should be byte-exact identity");
+    }
+
+    #[test]
+    fn dry_eye_strength_zero_is_identity() {
+        let size = 32_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 7) as u8, (y * 7) as u8, 128, 255]);
+        }
+        let orig = img.clone().into_raw();
+        let out = dry_eye(DynamicImage::ImageRgba8(img), 0.0).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        assert_eq!(orig, out_raw, "dry_eye strength=0 should be byte-exact identity");
+    }
+
+    #[test]
+    fn eye_strain_reduces_contrast() {
+        // 真っ白と真っ黒が混在する画像で strength=1 の分散が strength=0 より小さいことを確認
+        let size = 32_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, _y, px) in img.enumerate_pixels_mut() {
+            let v = if x < size / 2 { 0u8 } else { 255u8 };
+            *px = Rgba([v, v, v, 255]);
+        }
+        let out = eye_strain(DynamicImage::ImageRgba8(img), 1.0).unwrap();
+        let out_raw = out.to_rgba8();
+        // 最大値 - 最小値がコントラスト圧縮で小さくなっているはず
+        let min_r = out_raw.pixels().map(|p| p[0]).min().unwrap_or(0);
+        let max_r = out_raw.pixels().map(|p| p[0]).max().unwrap_or(255);
+        assert!(
+            (max_r as i32 - min_r as i32) < 255,
+            "eye_strain should reduce contrast: min={min_r} max={max_r}"
+        );
     }
 }


### PR DESCRIPTION
Closes #38
Closes #39
Closes #40

## 変更内容
- floaters: 糸くず形状追加、seed を実際に使用
- tetrachromacy: メタメリズムベースアルゴリズムに刷新
- cataract: 黄変マトリクス + コントラスト圧縮追加