### PR TITLE
fix: depth_aware_blur のビン境界アーティファクト修正（線形補間） (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **vision: depth_aware_blur をビン線形補間に変更** (#54):
+  深度値を 8 段階ビンに量子化して不連続に切り替える方式を廃止し、隣接 2 ビンの blur 結果を線形補間する方式に変更。
+  `t = frac(d * 7.0)` を補間係数として `out = blur[bin_floor] * (1-t) + blur[bin_ceil] * t` を適用し、ビン境界でのバンディングアーティファクトを除去。
+  メモリ使用量を 8 枚同時保持から 2 枚逐次処理に削減。
+
 ### Fixed
 
 - **BREAKING: vision: diplopia を加算合成から alpha blend に修正** (#53):

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -1536,10 +1536,18 @@ pub enum DepthBlurKind {
 /// `max_radius_ratio`: 最大ボケ半径（min(W,H) 比）。0.023 が近視最大相当。
 /// `kind`: DepthBlurKind で近視・遠視・DoF を切り替え。
 ///
-/// # アルゴリズム（8段階量子化ビン方式）
+/// # アルゴリズム（8段階ビン線形補間方式）
 ///
 /// 画素ごとに異なる半径の blur を掛けると O(W×H×R²) になって遅い。
-/// 8段階の深度ビンに量子化し、各ビンに対して1枚の blur 画像を生成してブレンドする。
+/// 8段階の深度ビンを定義し、各画素の深度値 `d` に対して隣接する 2 ビン
+/// （bin_floor, bin_ceil）の blur 画像を逐次生成して線形補間する:
+///
+/// ```text
+/// t = frac(d * 7.0)   // 0.0..1.0 の小数部（最終ビンは t = 0 で固定）
+/// out = blur[bin_floor] * (1 - t) + blur[bin_ceil] * t
+/// ```
+///
+/// メモリは 8 枚同時保持から 2 枚逐次処理に変更し、アーティファクトを除去する。
 pub fn depth_aware_blur(
     img: DynamicImage,
     depth_map: &DynamicImage,
@@ -1583,27 +1591,83 @@ pub fn depth_aware_blur(
     // linear sRGB planes に変換
     let (linear, alpha) = rgba_to_linear_planes(&rgba);
 
-    // 各ビンの blur 済み全画像を生成（radius < MIN_BLUR_RADIUS_PX は元画像と同じ）
-    let bin_blurred: Vec<Vec<[f32; 3]>> = (0..N_BINS)
-        .map(|bin| {
-            let r = bin_radius[bin];
-            if r < MIN_BLUR_RADIUS_PX {
-                linear.clone()
-            } else {
-                ellipse_blur(&linear, w, h, r, r, 0.0)
-            }
-        })
+    // 出力バッファ
+    let npx = (w * h) as usize;
+    let mut out_linear: Vec<[f32; 3]> = vec![[0.0; 3]; npx];
+
+    // 各画素の深度値を事前収集（0.0..=1.0）
+    let depths: Vec<f32> = (0..h)
+        .flat_map(|y| (0..w).map(move |x| (y, x)))
+        .map(|(y, x)| depth_gray.get_pixel(x, y)[0] as f32 / 255.0)
         .collect();
 
-    // 各画素のビンを決定して合成
-    let mut out_linear: Vec<[f32; 3]> = vec![[0.0; 3]; (w * h) as usize];
-    for y in 0..h {
-        for x in 0..w {
-            let d = depth_gray.get_pixel(x, y)[0] as f32 / 255.0; // 0.0..=1.0
-            // ビン番号（0..N_BINS）に量子化
-            let bin = ((d * N_BINS as f32) as usize).min(N_BINS - 1);
-            let idx = (y * w + x) as usize;
-            out_linear[idx] = bin_blurred[bin][idx];
+    // 隣接 2 ビンを逐次処理して線形補間する。
+    // depth d に対して:
+    //   scaled = d * (N_BINS - 1) as f32   → 0.0..=7.0
+    //   bin_floor = scaled.floor() as usize  → 0..=7
+    //   bin_ceil  = (bin_floor + 1).min(N_BINS - 1)
+    //   t         = scaled.fract()           → 0.0..=1.0
+    // 出力 = lerp(blur_floor[i], blur_ceil[i], t)
+    //
+    // ビンペアを (0,1), (1,2), ..., (6,7) と順に処理し、
+    // そのペアが使われる画素にだけ書き込む（2 枚しか同時保持しない）。
+    for floor_bin in 0..(N_BINS - 1) {
+        let ceil_bin = floor_bin + 1;
+
+        // このペアを使う画素が存在するか確認
+        let pair_used = depths.iter().any(|&d| {
+            let scaled = d * (N_BINS - 1) as f32;
+            let bf = (scaled.floor() as usize).min(N_BINS - 1);
+            bf == floor_bin
+        });
+        if !pair_used {
+            continue;
+        }
+
+        // 2 枚の blur 画像を生成
+        let blur_floor = if bin_radius[floor_bin] < MIN_BLUR_RADIUS_PX {
+            linear.clone()
+        } else {
+            ellipse_blur(&linear, w, h, bin_radius[floor_bin], bin_radius[floor_bin], 0.0)
+        };
+        let blur_ceil = if bin_radius[ceil_bin] < MIN_BLUR_RADIUS_PX {
+            linear.clone()
+        } else {
+            ellipse_blur(&linear, w, h, bin_radius[ceil_bin], bin_radius[ceil_bin], 0.0)
+        };
+
+        // 該当画素に線形補間結果を書き込む
+        for (idx, &d) in depths.iter().enumerate() {
+            let scaled = d * (N_BINS - 1) as f32;
+            let bf = (scaled.floor() as usize).min(N_BINS - 1);
+            if bf == floor_bin {
+                let t = scaled.fract();
+                let f = blur_floor[idx];
+                let c = blur_ceil[idx];
+                out_linear[idx] = [
+                    lerp(f[0], c[0], t),
+                    lerp(f[1], c[1], t),
+                    lerp(f[2], c[2], t),
+                ];
+            }
+        }
+    }
+
+    // 最終ビン（bin 7）: scaled = 7.0 → fract = 0.0 → floor = 7 → ceil = 7（clamp）
+    // このケースは floor_bin が 6 のループで bf = 6 となり補間されない。
+    // d = 1.0 のとき scaled = 7.0, floor = 7 → 別途処理する。
+    {
+        let blur_last = if bin_radius[N_BINS - 1] < MIN_BLUR_RADIUS_PX {
+            linear.clone()
+        } else {
+            ellipse_blur(&linear, w, h, bin_radius[N_BINS - 1], bin_radius[N_BINS - 1], 0.0)
+        };
+        for (idx, &d) in depths.iter().enumerate() {
+            let scaled = d * (N_BINS - 1) as f32;
+            let bf = (scaled.floor() as usize).min(N_BINS - 1);
+            if bf == N_BINS - 1 {
+                out_linear[idx] = blur_last[idx];
+            }
         }
     }
 

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -4017,7 +4017,7 @@ mod tests {
         // 中央 white dot が拡散して中心輝度が下がるはず。
         let size = 64_u32;
         let input = center_white_dot(size);
-        let depth_max = depth_map_solid(size, 255); // d≈1.0 → scaled≈6.972
+        let depth_max = depth_map_solid(size, 255); // d=1.0 → scaled=7.0 → 最終ビン
 
         let out_blurred = depth_aware_blur(
             input.clone(),

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -3978,6 +3978,190 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
+    // DA-06: strength=0 → identity（blur なし）
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn depth_aware_blur_zero_strength_is_identity() {
+        // max_radius_ratio=0.0 のとき radius=0 → どの画素もボケない。
+        // 出力が入力と画素単位で一致することを確認。
+        let size = 32_u32;
+        let input = center_white_dot(size);
+        let depth = depth_map_solid(size, 0); // 深度任意
+
+        let out = depth_aware_blur(
+            input.clone(),
+            &depth,
+            1.0,
+            0.0, // max_radius_ratio=0 → radius=0
+            DepthBlurKind::Myopia,
+        )
+        .unwrap();
+
+        let in_bytes = input.to_rgba8().into_raw();
+        let out_bytes = out.to_rgba8().into_raw();
+        assert_eq!(
+            in_bytes, out_bytes,
+            "max_radius_ratio=0.0 must produce identical output (identity)"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // DA-07: d=1.0 → scaled=7.0, fract=0.0, 最終ビンが正しく処理される
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn depth_aware_blur_d1_uses_last_bin() {
+        // d=1.0 のとき scaled=7.0, floor=7（N_BINS-1）→ 最終ビン専用パスで処理される。
+        // DepthOfField, focus=0.0 → d=1.0 は最大 delta=1.0 → 最大ボケ。
+        // 中央 white dot が拡散して中心輝度が下がるはず。
+        let size = 64_u32;
+        let input = center_white_dot(size);
+        let depth_max = depth_map_solid(size, 255); // d≈1.0 → scaled≈6.972
+
+        let out_blurred = depth_aware_blur(
+            input.clone(),
+            &depth_max,
+            0.0,
+            0.1,
+            DepthBlurKind::DepthOfField,
+        )
+        .unwrap();
+
+        // d=0.0（focus=0.0 と一致）はシャープ
+        let depth_zero = depth_map_solid(size, 0);
+        let out_sharp = depth_aware_blur(
+            input,
+            &depth_zero,
+            0.0,
+            0.1,
+            DepthBlurKind::DepthOfField,
+        )
+        .unwrap();
+
+        let cx = size / 2;
+        let cy = size / 2;
+        let blurred_center = out_blurred.to_rgba8().get_pixel(cx, cy)[0];
+        let sharp_center = out_sharp.to_rgba8().get_pixel(cx, cy)[0];
+        assert!(
+            blurred_center < sharp_center,
+            "d=1.0 (last bin) must be more blurred than d=0.0 (focus): \
+             blurred={blurred_center}, sharp={sharp_center}"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // DA-08: 線形補間 — ビン境界中間の深度が両端の中間的なボケ量になる
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn depth_aware_blur_lerp_intermediate_depth_is_between_endpoints() {
+        // DepthOfField, focus=0.0。ビン0とビン1の境界付近を使う。
+        // depth=0/255 と depth=36/255（ビン0とビン1の中間付近）と depth=18/255（その中間）を比較。
+        // ボケ量が単調増加（depth が大きい → delta が大きい → blur が強い）かを確認。
+        let size = 64_u32;
+        let input = center_white_dot(size);
+
+        // depth val=0  → d≈0.000 → delta=0.000 → radius≈0   → シャープ
+        let out_near = depth_aware_blur(
+            input.clone(),
+            &depth_map_solid(size, 0),
+            0.0,
+            0.1,
+            DepthBlurKind::DepthOfField,
+        )
+        .unwrap();
+
+        // depth val=18 → d≈0.071 → scaled≈0.496 → ビン0/1境界手前
+        let out_mid = depth_aware_blur(
+            input.clone(),
+            &depth_map_solid(size, 18),
+            0.0,
+            0.1,
+            DepthBlurKind::DepthOfField,
+        )
+        .unwrap();
+
+        // depth val=36 → d≈0.141 → scaled≈0.988 → ビン0/1境界ほぼ手前
+        let out_far = depth_aware_blur(
+            input,
+            &depth_map_solid(size, 36),
+            0.0,
+            0.1,
+            DepthBlurKind::DepthOfField,
+        )
+        .unwrap();
+
+        let cx = size / 2;
+        let cy = size / 2;
+        let c_near = out_near.to_rgba8().get_pixel(cx, cy)[0];
+        let c_mid = out_mid.to_rgba8().get_pixel(cx, cy)[0];
+        let c_far = out_far.to_rgba8().get_pixel(cx, cy)[0];
+
+        // blur が強いほど中心輝度が下がる（単調減少）
+        assert!(
+            c_near >= c_mid,
+            "depth=0 must be at least as sharp as depth=18: near={c_near}, mid={c_mid}"
+        );
+        assert!(
+            c_mid >= c_far,
+            "depth=18 must be at least as sharp as depth=36: mid={c_mid}, far={c_far}"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // DA-09: 異なる深度が混在する画像でも画素ごとに正しいビンが適用される
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn depth_aware_blur_per_pixel_bin_assignment() {
+        // 左半分 depth=0（シャープ）, 右半分 depth=255（ボケ）の depth_map を作成。
+        // 中央に white dot（左端付近）。Myopia, focus=1.0。
+        // 左の dot 領域（depth=0, 遠方）はボケ、右半分のピクセルは depth=255（近方）→ シャープ。
+        use image::{GrayImage, Luma};
+
+        let size = 64_u32;
+
+        // 左半分白 dot の入力画像
+        let mut rgba_img = image::RgbaImage::from_pixel(size, size, image::Rgba([0, 0, 0, 255]));
+        rgba_img.put_pixel(size / 4, size / 2, image::Rgba([255, 255, 255, 255]));
+        let input = DynamicImage::ImageRgba8(rgba_img);
+
+        // 左半分 depth=0, 右半分 depth=255 の depth_map
+        let mut depth_img = GrayImage::new(size, size);
+        for y in 0..size {
+            for x in 0..size {
+                let val = if x < size / 2 { 0u8 } else { 255u8 };
+                depth_img.put_pixel(x, y, Luma([val]));
+            }
+        }
+        let depth = DynamicImage::ImageLuma8(depth_img);
+
+        let out = depth_aware_blur(
+            input,
+            &depth,
+            1.0, // focus=1.0
+            0.1,
+            DepthBlurKind::Myopia,
+        )
+        .unwrap();
+
+        // 左の dot（depth=0, 遠方）はボケるので (size/4, size/2) 中心輝度が下がる
+        let dot_center = out.to_rgba8().get_pixel(size / 4, size / 2)[0];
+        // 右エリア（depth=255, 近方）は元々黒なので変化しない（ボケない）
+        let right_px = out.to_rgba8().get_pixel(3 * size / 4, size / 2)[0];
+
+        assert!(
+            dot_center < 255,
+            "left dot (depth=0, far from focus=1.0) must be blurred: dot_center={dot_center}"
+        );
+        assert_eq!(
+            right_px, 0,
+            "right area (depth=255, near=focus) must stay black (no blur source): right={right_px}"
+        );
+    }
+
+    // ---------------------------------------------------------------
     // #29: diplopia / nystagmus / starbursts
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## 関連 Issue

closes #54

## 変更内容

### 問題

以前の実装では各画素を最も近いビン（N=8）に量子化して blur 半径を決定していたため、ビン境界でブロック状のアーティファクト（急激な blur 量の変化）が発生していた。

### 修正

`depth_aware_blur` の内部処理を量子化ビン割り当てから **線形補間（lerp）** に変更:

- `scaled = d * (N_BINS - 1)` で 0.0〜7.0 に写像
- `bin_floor = scaled.floor()`、`bin_ceil = floor + 1`、`t = scaled.fract()`
- 出力 = `lerp(blur_floor[px], blur_ceil[px], t)`
- 同時に保持する blur 画像を 2 枚に削減（メモリ効率改善）
- d=1.0 の最終ビン（scaled=7.0, fract=0.0）は専用パスで処理

## テスト追加

4 件追加:

| # | テスト名 | 観点 |
|---|---|---|
| DA-06 | `depth_aware_blur_zero_strength_is_identity` | max_radius_ratio=0.0 → 入力と完全一致 |
| DA-07 | `depth_aware_blur_d1_uses_last_bin` | d=1.0（scaled=7.0）が最終ビン専用パスで正しく処理される |
| DA-08 | `depth_aware_blur_lerp_intermediate_depth_is_between_endpoints` | 中間深度のblur量が単調増加（補間が滑らか） |
| DA-09 | `depth_aware_blur_per_pixel_bin_assignment` | 混在depth画像で画素ごとに正しいビンが適用される |

`cargo test depth`: 26/26 通過