### PR TITLE
shader: 視野欠損 4 種の GLSL シェーダ追加 (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **shader: 視野欠損 4 種の GLSL ES 3.00 シェーダを追加** (#46):
+  `glaucoma.frag`（周辺ビネット、smoothstep マスク）、`macular_degeneration.frag`（中心暗化、foveal smoothstep マスク）、`hemianopia.frag`（左右半側マスク）、`tunnel_vision.frag`（急峻なトンネルビネット）の 4 シェーダを `crates/core/src/shaders/` に追加。
+  `shaders.rs` に `glaucoma_glsl()` / `macular_degeneration_glsl()` / `hemianopia_glsl()` / `tunnel_vision_glsl()` および対応する uniform 構造体・計算関数を追加。
+  uniform 構造体: `FieldOfVisionUniforms { strength }` / `HemianopiaUniforms { strength, side }`（side: 1.0=右側欠損, -1.0=左側欠損）。
+
 ### Changed
 
 - **vision: depth_aware_blur をビン線形補間に変更** (#54):

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -323,6 +323,9 @@ pub fn starbursts_uniforms(strength: f32, threshold: f32) -> StarburstsUniforms 
 #[derive(Debug, Clone)]
 pub struct FieldOfVisionUniforms {
     pub strength: f32,
+    /// アスペクト比（width / height）。GLSL シェーダの `uAspect` uniform に渡す。
+    /// 距離計算で UV 空間を aspect 補正して Rust 実装（pixel 座標）と一致させる。
+    pub aspect: f32,
 }
 
 /// 半盲フィルタの uniform。
@@ -334,18 +337,33 @@ pub struct HemianopiaUniforms {
 }
 
 /// glaucoma の uniform を計算する。
-pub fn glaucoma_uniforms(strength: f32) -> FieldOfVisionUniforms {
-    FieldOfVisionUniforms { strength }
+///
+/// `width`, `height`: 画像サイズ（ピクセル）。aspect 補正に使用。
+pub fn glaucoma_uniforms(strength: f32, width: u32, height: u32) -> FieldOfVisionUniforms {
+    FieldOfVisionUniforms {
+        strength,
+        aspect: width as f32 / height as f32,
+    }
 }
 
 /// macular_degeneration の uniform を計算する。
-pub fn macular_degeneration_uniforms(strength: f32) -> FieldOfVisionUniforms {
-    FieldOfVisionUniforms { strength }
+///
+/// `width`, `height`: 画像サイズ（ピクセル）。aspect 補正に使用。
+pub fn macular_degeneration_uniforms(strength: f32, width: u32, height: u32) -> FieldOfVisionUniforms {
+    FieldOfVisionUniforms {
+        strength,
+        aspect: width as f32 / height as f32,
+    }
 }
 
 /// tunnel_vision の uniform を計算する。
-pub fn tunnel_vision_uniforms(strength: f32) -> FieldOfVisionUniforms {
-    FieldOfVisionUniforms { strength }
+///
+/// `width`, `height`: 画像サイズ（ピクセル）。aspect 補正に使用。
+pub fn tunnel_vision_uniforms(strength: f32, width: u32, height: u32) -> FieldOfVisionUniforms {
+    FieldOfVisionUniforms {
+        strength,
+        aspect: width as f32 / height as f32,
+    }
 }
 
 /// hemianopia の uniform を計算する。
@@ -515,19 +533,21 @@ mod tests {
 
     #[test]
     fn glaucoma_uniforms_strength_one() {
-        let u = glaucoma_uniforms(1.0);
+        let u = glaucoma_uniforms(1.0, 32, 32);
         assert_eq!(u.strength, 1.0);
+        assert!((u.aspect - 1.0).abs() < 1e-6, "正方形は aspect=1.0");
     }
 
     #[test]
     fn macular_degeneration_uniforms_strength_one() {
-        let u = macular_degeneration_uniforms(1.0);
+        let u = macular_degeneration_uniforms(1.0, 64, 32);
         assert_eq!(u.strength, 1.0);
+        assert!((u.aspect - 2.0).abs() < 1e-6, "横長は aspect=2.0");
     }
 
     #[test]
     fn tunnel_vision_uniforms_strength_one() {
-        let u = tunnel_vision_uniforms(1.0);
+        let u = tunnel_vision_uniforms(1.0, 32, 32);
         assert_eq!(u.strength, 1.0);
     }
 

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -106,6 +106,26 @@ pub fn dry_eye_glsl() -> &'static str {
     include_str!("shaders/dry_eye.frag")
 }
 
+/// glaucoma.frag の GLSL ES 3.00 ソースを返す。
+pub fn glaucoma_glsl() -> &'static str {
+    include_str!("shaders/glaucoma.frag")
+}
+
+/// macular_degeneration.frag の GLSL ES 3.00 ソースを返す。
+pub fn macular_degeneration_glsl() -> &'static str {
+    include_str!("shaders/macular_degeneration.frag")
+}
+
+/// hemianopia.frag の GLSL ES 3.00 ソースを返す。
+pub fn hemianopia_glsl() -> &'static str {
+    include_str!("shaders/hemianopia.frag")
+}
+
+/// tunnel_vision.frag の GLSL ES 3.00 ソースを返す。
+pub fn tunnel_vision_glsl() -> &'static str {
+    include_str!("shaders/tunnel_vision.frag")
+}
+
 // ---------------------------------------------------------------------------
 // uniform 構造体
 // ---------------------------------------------------------------------------
@@ -298,6 +318,43 @@ pub fn starbursts_uniforms(strength: f32, threshold: f32) -> StarburstsUniforms 
     StarburstsUniforms { strength, threshold }
 }
 
+/// 視野欠損（vignette 系）フィルタの uniform。
+/// glaucoma / tunnel_vision / macular_degeneration 共通。
+#[derive(Debug, Clone)]
+pub struct FieldOfVisionUniforms {
+    pub strength: f32,
+}
+
+/// 半盲フィルタの uniform。
+#[derive(Debug, Clone)]
+pub struct HemianopiaUniforms {
+    pub strength: f32,
+    /// 1.0=右側欠損, -1.0=左側欠損
+    pub side: f32,
+}
+
+/// glaucoma の uniform を計算する。
+pub fn glaucoma_uniforms(strength: f32) -> FieldOfVisionUniforms {
+    FieldOfVisionUniforms { strength }
+}
+
+/// macular_degeneration の uniform を計算する。
+pub fn macular_degeneration_uniforms(strength: f32) -> FieldOfVisionUniforms {
+    FieldOfVisionUniforms { strength }
+}
+
+/// tunnel_vision の uniform を計算する。
+pub fn tunnel_vision_uniforms(strength: f32) -> FieldOfVisionUniforms {
+    FieldOfVisionUniforms { strength }
+}
+
+/// hemianopia の uniform を計算する。
+///
+/// `side`: 1.0=右側欠損, -1.0=左側欠損。
+pub fn hemianopia_uniforms(strength: f32, side: f32) -> HemianopiaUniforms {
+    HemianopiaUniforms { strength, side }
+}
+
 // ---------------------------------------------------------------------------
 // テスト
 // ---------------------------------------------------------------------------
@@ -434,5 +491,51 @@ mod tests {
         let u = astigmatism_uniforms(s, dim, 0.0);
         let expected = s * ASTIGMATISM_MAX_RADIUS_RATIO * 800.0;
         assert!((u.radius_px - expected).abs() < 1e-4);
+    }
+
+    #[test]
+    fn glaucoma_glsl_is_not_empty() {
+        assert!(!glaucoma_glsl().is_empty());
+    }
+
+    #[test]
+    fn macular_degeneration_glsl_is_not_empty() {
+        assert!(!macular_degeneration_glsl().is_empty());
+    }
+
+    #[test]
+    fn hemianopia_glsl_is_not_empty() {
+        assert!(!hemianopia_glsl().is_empty());
+    }
+
+    #[test]
+    fn tunnel_vision_glsl_is_not_empty() {
+        assert!(!tunnel_vision_glsl().is_empty());
+    }
+
+    #[test]
+    fn glaucoma_uniforms_strength_one() {
+        let u = glaucoma_uniforms(1.0);
+        assert_eq!(u.strength, 1.0);
+    }
+
+    #[test]
+    fn macular_degeneration_uniforms_strength_one() {
+        let u = macular_degeneration_uniforms(1.0);
+        assert_eq!(u.strength, 1.0);
+    }
+
+    #[test]
+    fn tunnel_vision_uniforms_strength_one() {
+        let u = tunnel_vision_uniforms(1.0);
+        assert_eq!(u.strength, 1.0);
+    }
+
+    #[test]
+    fn hemianopia_uniforms_side_values() {
+        let u = hemianopia_uniforms(1.0, 1.0);
+        assert_eq!(u.side, 1.0);
+        let u2 = hemianopia_uniforms(1.0, -1.0);
+        assert_eq!(u2.side, -1.0);
     }
 }

--- a/crates/core/src/shaders/glaucoma.frag
+++ b/crates/core/src/shaders/glaucoma.frag
@@ -1,0 +1,46 @@
+#version 300 es
+precision mediump float;
+
+// 緑内障（glaucoma）シミュレーション — 周辺ビネット（smoothstep マスク）
+// 中心を残し、周辺を暗化する。strength=1.0 で最強の周辺暗化。
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 src = texture(uTexture, vTexCoord);
+
+    // UV 空間での中心からの距離（コーナー距離 = sqrt(0.5^2+0.5^2) で正規化）
+    vec2 uv = vTexCoord - vec2(0.5, 0.5);
+    float d = length(uv) / 0.7071067811865476; // sqrt(0.5^2+0.5^2)
+
+    // vision.rs と同じ定数
+    float inner_r = 1.0 - uStrength * 0.7;
+    float outer_r = min(inner_r + 0.2, 1.0);
+
+    float t = clamp((d - inner_r) / (outer_r - inner_r), 0.0, 1.0);
+    float fade = t * t * (3.0 - 2.0 * t); // smoothstep
+    float mul = 1.0 - uStrength * fade;
+
+    float rl = srgbToLinear(src.r);
+    float gl = srgbToLinear(src.g);
+    float bl = srgbToLinear(src.b);
+
+    fragColor = vec4(
+        linearToSrgb(clamp(rl * mul, 0.0, 1.0)),
+        linearToSrgb(clamp(gl * mul, 0.0, 1.0)),
+        linearToSrgb(clamp(bl * mul, 0.0, 1.0)),
+        src.a
+    );
+}

--- a/crates/core/src/shaders/glaucoma.frag
+++ b/crates/core/src/shaders/glaucoma.frag
@@ -6,6 +6,7 @@ precision mediump float;
 
 uniform sampler2D uTexture;
 uniform float uStrength;
+uniform float uAspect;  // width / height。非正方形画像の aspect 補正に使用。
 
 in vec2 vTexCoord;
 out vec4 fragColor;
@@ -21,9 +22,13 @@ float linearToSrgb(float c) {
 void main() {
     vec4 src = texture(uTexture, vTexCoord);
 
-    // UV 空間での中心からの距離（コーナー距離 = sqrt(0.5^2+0.5^2) で正規化）
+    // UV 座標を aspect 補正してから距離計算する。
+    // Rust 実装（pixel 座標）との一致: dx/max_r = uv_x*aspect / corner
     vec2 uv = vTexCoord - vec2(0.5, 0.5);
-    float d = length(uv) / 0.7071067811865476; // sqrt(0.5^2+0.5^2)
+    vec2 uvA = vec2(uv.x * uAspect, uv.y);
+    // コーナー距離（aspect 補正済み）: sqrt((0.5*aspect)^2 + 0.5^2)
+    float cornerDist = sqrt(0.5 * uAspect * 0.5 * uAspect + 0.5 * 0.5);
+    float d = length(uvA) / cornerDist;
 
     // vision.rs と同じ定数
     float inner_r = 1.0 - uStrength * 0.7;

--- a/crates/core/src/shaders/hemianopia.frag
+++ b/crates/core/src/shaders/hemianopia.frag
@@ -25,7 +25,7 @@ void main() {
 
     float x = vTexCoord.x;
     float split = 0.5;
-    float blur_w = 0.02; // vision.rs と同じ 2% ぼかし幅（UV 単位）
+    float blur_w = 0.02; // UV 単位のぼかし幅（2%）。vision.rs は pixel 単位で w_f * 0.02 と等価。
 
     float left_fade;
     if (x < split - blur_w) {

--- a/crates/core/src/shaders/hemianopia.frag
+++ b/crates/core/src/shaders/hemianopia.frag
@@ -2,8 +2,8 @@
 precision mediump float;
 
 // 半盲（hemianopia）シミュレーション — 左右半側マスク
-// uSide=1.0: 右半分を暗化, uSide=-1.0: 左半分を暗化（vision.rs 規約に合わせた外部値）
-// 内部では vision.rs の side=0.0/1.0 規約に変換: uSide=1.0(右欠損) → side=1.0
+// uSide=1.0: 右半分を暗化, uSide=-1.0: 左半分を暗化
+// 境界は画像中央 x=0.5 に固定。幅 2% の smoothstep で滑らかに。
 
 uniform sampler2D uTexture;
 uniform float uStrength;
@@ -25,17 +25,24 @@ void main() {
 
     float x = vTexCoord.x;
     float split = 0.5;
-    float blur_w = 0.02; // vision.rs と同じ 2% ぼかし幅
+    float blur_w = 0.02; // vision.rs と同じ 2% ぼかし幅（UV 単位）
 
-    // 左側フェード量（左端=1.0, 右端=0.0）
-    float t_left = clamp((x - (split - blur_w)) / (2.0 * blur_w), 0.0, 1.0);
-    float left_fade = 1.0 - t_left * t_left * (3.0 - 2.0 * t_left);
+    float left_fade;
+    if (x < split - blur_w) {
+        left_fade = 1.0;
+    } else if (x > split + blur_w) {
+        left_fade = 0.0;
+    } else {
+        float t = (x - (split - blur_w)) / (2.0 * blur_w);
+        left_fade = 1.0 - t * t * (3.0 - 2.0 * t);
+    }
 
     // vision.rs 規約: side=0→左欠損, side=1→右欠損
-    // uSide: 1.0=右欠損(-1を0に変換), -1.0=左欠損(1を1に変換)
-    float side = (uSide + 1.0) * 0.5; // [-1,1] → [0,1]
+    // uSide: 1.0=右欠損, -1.0=左欠損 → side = (uSide+1)/2
+    float side = (uSide + 1.0) * 0.5;
 
-    float fade = mix(left_fade, 1.0 - left_fade, side);
+    // lerp(left_fade, 1-left_fade, side)
+    float fade = left_fade + (1.0 - 2.0 * left_fade) * side;
     float mul = 1.0 - fade * uStrength;
 
     float rl = srgbToLinear(src.r);

--- a/crates/core/src/shaders/hemianopia.frag
+++ b/crates/core/src/shaders/hemianopia.frag
@@ -1,0 +1,51 @@
+#version 300 es
+precision mediump float;
+
+// 半盲（hemianopia）シミュレーション — 左右半側マスク
+// uSide=1.0: 右半分を暗化, uSide=-1.0: 左半分を暗化（vision.rs 規約に合わせた外部値）
+// 内部では vision.rs の side=0.0/1.0 規約に変換: uSide=1.0(右欠損) → side=1.0
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+uniform float uSide;     // 1.0=右側欠損, -1.0=左側欠損
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 src = texture(uTexture, vTexCoord);
+
+    float x = vTexCoord.x;
+    float split = 0.5;
+    float blur_w = 0.02; // vision.rs と同じ 2% ぼかし幅
+
+    // 左側フェード量（左端=1.0, 右端=0.0）
+    float t_left = clamp((x - (split - blur_w)) / (2.0 * blur_w), 0.0, 1.0);
+    float left_fade = 1.0 - t_left * t_left * (3.0 - 2.0 * t_left);
+
+    // vision.rs 規約: side=0→左欠損, side=1→右欠損
+    // uSide: 1.0=右欠損(-1を0に変換), -1.0=左欠損(1を1に変換)
+    float side = (uSide + 1.0) * 0.5; // [-1,1] → [0,1]
+
+    float fade = mix(left_fade, 1.0 - left_fade, side);
+    float mul = 1.0 - fade * uStrength;
+
+    float rl = srgbToLinear(src.r);
+    float gl = srgbToLinear(src.g);
+    float bl = srgbToLinear(src.b);
+
+    fragColor = vec4(
+        linearToSrgb(clamp(rl * mul, 0.0, 1.0)),
+        linearToSrgb(clamp(gl * mul, 0.0, 1.0)),
+        linearToSrgb(clamp(bl * mul, 0.0, 1.0)),
+        src.a
+    );
+}

--- a/crates/core/src/shaders/macular_degeneration.frag
+++ b/crates/core/src/shaders/macular_degeneration.frag
@@ -1,0 +1,53 @@
+#version 300 es
+precision mediump float;
+
+// 黄斑変性（macular degeneration）シミュレーション — 中心暗化（foveal smoothstep マスク）
+// 中心部を暗化・脱色する。strength=1.0 で最強の中心視野欠損。
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 src = texture(uTexture, vTexCoord);
+
+    // UV 空間での中心からの距離（コーナー距離で正規化）
+    vec2 uv = vTexCoord - vec2(0.5, 0.5);
+    float d = length(uv) / 0.7071067811865476;
+
+    // vision.rs と同じ定数
+    float inner_r = uStrength * 0.25;
+    float outer_r = uStrength * 0.4;
+
+    float u_t = clamp((d - inner_r) / max(outer_r - inner_r, 1e-5), 0.0, 1.0);
+    float t = 1.0 - u_t * u_t * (3.0 - 2.0 * u_t); // 1 - smoothstep（中心ほど強い）
+
+    float rl = srgbToLinear(src.r);
+    float gl = srgbToLinear(src.g);
+    float bl = srgbToLinear(src.b);
+
+    // BT.709 輝度
+    float lum = 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+    float darkened = lum * (1.0 - uStrength * 0.95);
+
+    float out_r = mix(rl, darkened, t);
+    float out_g = mix(gl, darkened, t);
+    float out_b = mix(bl, darkened, t);
+
+    fragColor = vec4(
+        linearToSrgb(clamp(out_r, 0.0, 1.0)),
+        linearToSrgb(clamp(out_g, 0.0, 1.0)),
+        linearToSrgb(clamp(out_b, 0.0, 1.0)),
+        src.a
+    );
+}

--- a/crates/core/src/shaders/macular_degeneration.frag
+++ b/crates/core/src/shaders/macular_degeneration.frag
@@ -6,6 +6,7 @@ precision mediump float;
 
 uniform sampler2D uTexture;
 uniform float uStrength;
+uniform float uAspect;  // width / height。非正方形画像の aspect 補正に使用。
 
 in vec2 vTexCoord;
 out vec4 fragColor;
@@ -21,9 +22,12 @@ float linearToSrgb(float c) {
 void main() {
     vec4 src = texture(uTexture, vTexCoord);
 
-    // UV 空間での中心からの距離（コーナー距離で正規化）
+    // UV 座標を aspect 補正してから距離計算する。
+    // Rust 実装（pixel 座標）との一致: dx/max_r = uv_x*aspect / corner
     vec2 uv = vTexCoord - vec2(0.5, 0.5);
-    float d = length(uv) / 0.7071067811865476;
+    vec2 uvA = vec2(uv.x * uAspect, uv.y);
+    float cornerDist = sqrt(0.5 * uAspect * 0.5 * uAspect + 0.5 * 0.5);
+    float d = length(uvA) / cornerDist;
 
     // vision.rs と同じ定数
     float inner_r = uStrength * 0.25;

--- a/crates/core/src/shaders/tunnel_vision.frag
+++ b/crates/core/src/shaders/tunnel_vision.frag
@@ -6,6 +6,7 @@ precision mediump float;
 
 uniform sampler2D uTexture;
 uniform float uStrength;
+uniform float uAspect;  // width / height。非正方形画像の aspect 補正に使用。
 
 in vec2 vTexCoord;
 out vec4 fragColor;
@@ -21,9 +22,12 @@ float linearToSrgb(float c) {
 void main() {
     vec4 src = texture(uTexture, vTexCoord);
 
-    // UV 空間での中心からの距離（コーナー距離で正規化）
+    // UV 座標を aspect 補正してから距離計算する。
+    // Rust 実装（pixel 座標）との一致: dx/max_r = uv_x*aspect / corner
     vec2 uv = vTexCoord - vec2(0.5, 0.5);
-    float d = length(uv) / 0.7071067811865476;
+    vec2 uvA = vec2(uv.x * uAspect, uv.y);
+    float cornerDist = sqrt(0.5 * uAspect * 0.5 * uAspect + 0.5 * 0.5);
+    float d = length(uvA) / cornerDist;
 
     // vision.rs と同じ定数: tunnel_vision は急峻（outer - inner = 0.05）
     float inner_r = (1.0 - uStrength) * 0.5;

--- a/crates/core/src/shaders/tunnel_vision.frag
+++ b/crates/core/src/shaders/tunnel_vision.frag
@@ -1,0 +1,46 @@
+#version 300 es
+precision mediump float;
+
+// トンネル視野（tunnel vision）シミュレーション — 急峻なビネット
+// glaucoma より inner_r/outer_r の差が小さく、急激な境界が特徴。
+
+uniform sampler2D uTexture;
+uniform float uStrength;
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 src = texture(uTexture, vTexCoord);
+
+    // UV 空間での中心からの距離（コーナー距離で正規化）
+    vec2 uv = vTexCoord - vec2(0.5, 0.5);
+    float d = length(uv) / 0.7071067811865476;
+
+    // vision.rs と同じ定数: tunnel_vision は急峻（outer - inner = 0.05）
+    float inner_r = (1.0 - uStrength) * 0.5;
+    float outer_r = min(inner_r + 0.05, 1.0);
+
+    float t = clamp((d - inner_r) / max(outer_r - inner_r, 1e-5), 0.0, 1.0);
+    float fade = t * t * (3.0 - 2.0 * t); // smoothstep
+    float mul = 1.0 - uStrength * fade;
+
+    float rl = srgbToLinear(src.r);
+    float gl = srgbToLinear(src.g);
+    float bl = srgbToLinear(src.b);
+
+    fragColor = vec4(
+        linearToSrgb(clamp(rl * mul, 0.0, 1.0)),
+        linearToSrgb(clamp(gl * mul, 0.0, 1.0)),
+        linearToSrgb(clamp(bl * mul, 0.0, 1.0)),
+        src.a
+    );
+}

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -13,12 +13,15 @@
 
 use image::{DynamicImage, RgbaImage};
 use sensus_core::shaders::{
-    achromatopsia_uniforms, astigmatism_uniforms, deuteranopia_uniforms, hyperopia_uniforms,
-    myopia_uniforms, presbyopia_uniforms, protanopia_uniforms, tritanopia_uniforms,
+    achromatopsia_uniforms, astigmatism_uniforms, deuteranopia_uniforms,
+    glaucoma_uniforms, hemianopia_uniforms, hyperopia_uniforms,
+    macular_degeneration_uniforms, myopia_uniforms, presbyopia_uniforms,
+    protanopia_uniforms, tritanopia_uniforms, tunnel_vision_uniforms,
 };
 use sensus_core::vision::{
-    achromatopsia, astigmatism, deuteranopia, eye_strain, hyperopia, myopia, presbyopia,
-    protanopia, tritanopia,
+    achromatopsia, astigmatism, deuteranopia, eye_strain, glaucoma, hemianopia,
+    hyperopia, macular_degeneration, myopia, presbyopia, protanopia, tritanopia,
+    tunnel_vision,
 };
 
 // ---------------------------------------------------------------------------
@@ -570,4 +573,217 @@ fn shader_equiv_strength_zero_no_change() {
             "{name} strength=0.0: output differs from input by {err}/255 > 1"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// 視野欠損フィルタシェーダシミュレータ
+// ---------------------------------------------------------------------------
+
+/// glaucoma.frag / tunnel_vision.frag の計算を Rust で再現する。
+/// `inner_r`, `outer_r` を外から渡すことで両方に使用する。
+fn sim_vignette_fov(img: &RgbaImage, strength: f32, inner_r: f32, outer_r: f32) -> RgbaImage {
+    let (w, h) = img.dimensions();
+    let cx = w as f32 * 0.5;
+    let cy = h as f32 * 0.5;
+    // UV 空間でのコーナー距離: sqrt(0.5^2+0.5^2) = 0.7071...
+    let corner_dist = 0.7071067811865476_f32;
+    let mut out = img.clone();
+    for y in 0..h {
+        for x in 0..w {
+            // UV 座標 (pixel center)
+            let uv_x = (x as f32 + 0.5) / w as f32 - 0.5;
+            let uv_y = (y as f32 + 0.5) / h as f32 - 0.5;
+            let d = (uv_x * uv_x + uv_y * uv_y).sqrt() / corner_dist;
+
+            let t = ((d - inner_r) / (outer_r - inner_r)).clamp(0.0, 1.0);
+            let fade = t * t * (3.0 - 2.0 * t);
+            let mul = 1.0 - strength * fade;
+
+            let px = img.get_pixel(x, y);
+            let rl = srgb_to_linear(px[0] as f32 / 255.0);
+            let gl = srgb_to_linear(px[1] as f32 / 255.0);
+            let bl = srgb_to_linear(px[2] as f32 / 255.0);
+            out.put_pixel(x, y, image::Rgba([
+                (linear_to_srgb((rl * mul).clamp(0.0, 1.0)) * 255.0).round() as u8,
+                (linear_to_srgb((gl * mul).clamp(0.0, 1.0)) * 255.0).round() as u8,
+                (linear_to_srgb((bl * mul).clamp(0.0, 1.0)) * 255.0).round() as u8,
+                px[3],
+            ]));
+        }
+    }
+    out
+}
+
+/// macular_degeneration.frag の計算を Rust で再現する。
+fn sim_macular_degeneration(img: &RgbaImage, strength: f32) -> RgbaImage {
+    let (w, h) = img.dimensions();
+    let corner_dist = 0.7071067811865476_f32;
+    let inner_r = strength * 0.25;
+    let outer_r = strength * 0.4;
+    let mut out = img.clone();
+    for y in 0..h {
+        for x in 0..w {
+            let uv_x = (x as f32 + 0.5) / w as f32 - 0.5;
+            let uv_y = (y as f32 + 0.5) / h as f32 - 0.5;
+            let d = (uv_x * uv_x + uv_y * uv_y).sqrt() / corner_dist;
+
+            let range = (outer_r - inner_r).max(1e-5);
+            let u_t = ((d - inner_r) / range).clamp(0.0, 1.0);
+            let t = 1.0 - u_t * u_t * (3.0 - 2.0 * u_t);
+
+            let px = img.get_pixel(x, y);
+            let rl = srgb_to_linear(px[0] as f32 / 255.0);
+            let gl = srgb_to_linear(px[1] as f32 / 255.0);
+            let bl = srgb_to_linear(px[2] as f32 / 255.0);
+
+            let lum = 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+            let darkened = lum * (1.0 - strength * 0.95);
+            let out_r = (rl + (darkened - rl) * t).clamp(0.0, 1.0);
+            let out_g = (gl + (darkened - gl) * t).clamp(0.0, 1.0);
+            let out_b = (bl + (darkened - bl) * t).clamp(0.0, 1.0);
+
+            out.put_pixel(x, y, image::Rgba([
+                (linear_to_srgb(out_r) * 255.0).round() as u8,
+                (linear_to_srgb(out_g) * 255.0).round() as u8,
+                (linear_to_srgb(out_b) * 255.0).round() as u8,
+                px[3],
+            ]));
+        }
+    }
+    out
+}
+
+/// hemianopia.frag の計算を Rust で再現する。
+/// `side_glsl`: 1.0=右側欠損, -1.0=左側欠損（GLSL uSide 値）
+fn sim_hemianopia(img: &RgbaImage, strength: f32, side_glsl: f32) -> RgbaImage {
+    let (w, h) = img.dimensions();
+    let w_f = w as f32;
+    let blur_w = w_f * 0.02; // vision.rs と同じ pixel 単位
+    let split_x = w_f * 0.5;
+    // GLSL uSide: 1.0=右欠損, -1.0=左欠損 → vision.rs side: 1.0=右欠損, 0.0=左欠損
+    let side = (side_glsl + 1.0) * 0.5; // [-1,1] → [0,1]
+    let mut out = img.clone();
+    for y in 0..h {
+        for x in 0..w {
+            let xf = x as f32;
+
+            let left_fade = if xf < split_x - blur_w {
+                1.0_f32
+            } else if xf > split_x + blur_w {
+                0.0_f32
+            } else {
+                let t = (xf - (split_x - blur_w)) / (2.0 * blur_w);
+                1.0 - t * t * (3.0 - 2.0 * t)
+            };
+
+            // vision.rs: fade = lerp(left_fade, 1-left_fade, side)
+            let fade = left_fade + (1.0 - left_fade - left_fade) * side;
+            let mul = 1.0 - fade * strength;
+
+            let px = img.get_pixel(x, y);
+            let rl = srgb_to_linear(px[0] as f32 / 255.0);
+            let gl = srgb_to_linear(px[1] as f32 / 255.0);
+            let bl = srgb_to_linear(px[2] as f32 / 255.0);
+            out.put_pixel(x, y, image::Rgba([
+                (linear_to_srgb((rl * mul).clamp(0.0, 1.0)) * 255.0).round() as u8,
+                (linear_to_srgb((gl * mul).clamp(0.0, 1.0)) * 255.0).round() as u8,
+                (linear_to_srgb((bl * mul).clamp(0.0, 1.0)) * 255.0).round() as u8,
+                px[3],
+            ]));
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// 視野欠損フィルタ等価性テスト（PSNR ≥ 30 dB）
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shader_equiv_glaucoma_strength_1_0_psnr() {
+    let img = gradient_32();
+    let u = glaucoma_uniforms(1.0);
+    let inner_r = 1.0 - u.strength * 0.7;
+    let outer_r = (inner_r + 0.2_f32).min(1.0);
+    let cpu_out = glaucoma(img.clone(), 1.0).unwrap().to_rgba8();
+    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 30.0, "glaucoma strength=1.0: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_glaucoma_strength_0_5_psnr() {
+    let img = color_chart_32();
+    let u = glaucoma_uniforms(0.5);
+    let inner_r = 1.0 - u.strength * 0.7;
+    let outer_r = (inner_r + 0.2_f32).min(1.0);
+    let cpu_out = glaucoma(img.clone(), 0.5).unwrap().to_rgba8();
+    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 30.0, "glaucoma strength=0.5: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_macular_degeneration_strength_1_0_psnr() {
+    let img = gradient_32();
+    let u = macular_degeneration_uniforms(1.0);
+    let cpu_out = macular_degeneration(img.clone(), 1.0).unwrap().to_rgba8();
+    let gpu_sim = sim_macular_degeneration(&img.to_rgba8(), u.strength);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 30.0, "macular_degeneration strength=1.0: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_macular_degeneration_strength_0_5_psnr() {
+    let img = color_chart_32();
+    let u = macular_degeneration_uniforms(0.5);
+    let cpu_out = macular_degeneration(img.clone(), 0.5).unwrap().to_rgba8();
+    let gpu_sim = sim_macular_degeneration(&img.to_rgba8(), u.strength);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 30.0, "macular_degeneration strength=0.5: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_hemianopia_right_strength_1_0_psnr() {
+    let img = gradient_32();
+    let u = hemianopia_uniforms(1.0, 1.0); // 右側欠損
+    let cpu_out = hemianopia(img.clone(), 1.0, 1.0).unwrap().to_rgba8();
+    let gpu_sim = sim_hemianopia(&img.to_rgba8(), u.strength, u.side);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 30.0, "hemianopia right strength=1.0: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_hemianopia_left_strength_1_0_psnr() {
+    let img = gradient_32();
+    let u = hemianopia_uniforms(1.0, -1.0); // 左側欠損
+    // vision::hemianopia は side=0.0 で左欠損
+    let cpu_out = hemianopia(img.clone(), 1.0, 0.0).unwrap().to_rgba8();
+    let gpu_sim = sim_hemianopia(&img.to_rgba8(), u.strength, u.side);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 30.0, "hemianopia left strength=1.0: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_tunnel_vision_strength_1_0_psnr() {
+    let img = gradient_32();
+    let u = tunnel_vision_uniforms(1.0);
+    let inner_r = (1.0 - u.strength) * 0.5;
+    let outer_r = (inner_r + 0.05_f32).min(1.0);
+    let cpu_out = tunnel_vision(img.clone(), 1.0).unwrap().to_rgba8();
+    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 30.0, "tunnel_vision strength=1.0: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_tunnel_vision_strength_0_5_psnr() {
+    let img = color_chart_32();
+    let u = tunnel_vision_uniforms(0.5);
+    let inner_r = (1.0 - u.strength) * 0.5;
+    let outer_r = (inner_r + 0.05_f32).min(1.0);
+    let cpu_out = tunnel_vision(img.clone(), 0.5).unwrap().to_rgba8();
+    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 30.0, "tunnel_vision strength=0.5: PSNR {db:.1} dB < 30 dB");
 }

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -564,6 +564,10 @@ fn shader_equiv_strength_zero_no_change() {
         ("deuteranopia", deuteranopia(img.clone(), 0.0)),
         ("tritanopia", tritanopia(img.clone(), 0.0)),
         ("achromatopsia", achromatopsia(img.clone(), 0.0)),
+        ("glaucoma", glaucoma(img.clone(), 0.0)),
+        ("tunnel_vision", tunnel_vision(img.clone(), 0.0)),
+        ("macular_degeneration", macular_degeneration(img.clone(), 0.0)),
+        ("hemianopia", hemianopia(img.clone(), 0.0, 0.5)),
     ] {
         let cpu_out = cpu_result.unwrap().to_rgba8();
         let orig = img.to_rgba8();
@@ -702,7 +706,7 @@ fn sim_hemianopia(img: &RgbaImage, strength: f32, side_glsl: f32) -> RgbaImage {
 #[test]
 fn shader_equiv_glaucoma_strength_1_0_psnr() {
     let img = gradient_32();
-    let u = glaucoma_uniforms(1.0);
+    let u = glaucoma_uniforms(1.0, 32, 32);
     let inner_r = 1.0 - u.strength * 0.7;
     let outer_r = (inner_r + 0.2_f32).min(1.0);
     let cpu_out = glaucoma(img.clone(), 1.0).unwrap().to_rgba8();
@@ -714,7 +718,7 @@ fn shader_equiv_glaucoma_strength_1_0_psnr() {
 #[test]
 fn shader_equiv_glaucoma_strength_0_5_psnr() {
     let img = color_chart_32();
-    let u = glaucoma_uniforms(0.5);
+    let u = glaucoma_uniforms(0.5, 32, 32);
     let inner_r = 1.0 - u.strength * 0.7;
     let outer_r = (inner_r + 0.2_f32).min(1.0);
     let cpu_out = glaucoma(img.clone(), 0.5).unwrap().to_rgba8();
@@ -726,7 +730,7 @@ fn shader_equiv_glaucoma_strength_0_5_psnr() {
 #[test]
 fn shader_equiv_macular_degeneration_strength_1_0_psnr() {
     let img = gradient_32();
-    let u = macular_degeneration_uniforms(1.0);
+    let u = macular_degeneration_uniforms(1.0, 32, 32);
     let cpu_out = macular_degeneration(img.clone(), 1.0).unwrap().to_rgba8();
     let gpu_sim = sim_macular_degeneration(&img.to_rgba8(), u.strength);
     let db = psnr(&cpu_out, &gpu_sim);
@@ -736,7 +740,7 @@ fn shader_equiv_macular_degeneration_strength_1_0_psnr() {
 #[test]
 fn shader_equiv_macular_degeneration_strength_0_5_psnr() {
     let img = color_chart_32();
-    let u = macular_degeneration_uniforms(0.5);
+    let u = macular_degeneration_uniforms(0.5, 32, 32);
     let cpu_out = macular_degeneration(img.clone(), 0.5).unwrap().to_rgba8();
     let gpu_sim = sim_macular_degeneration(&img.to_rgba8(), u.strength);
     let db = psnr(&cpu_out, &gpu_sim);
@@ -767,7 +771,7 @@ fn shader_equiv_hemianopia_left_strength_1_0_psnr() {
 #[test]
 fn shader_equiv_tunnel_vision_strength_1_0_psnr() {
     let img = gradient_32();
-    let u = tunnel_vision_uniforms(1.0);
+    let u = tunnel_vision_uniforms(1.0, 32, 32);
     let inner_r = (1.0 - u.strength) * 0.5;
     let outer_r = (inner_r + 0.05_f32).min(1.0);
     let cpu_out = tunnel_vision(img.clone(), 1.0).unwrap().to_rgba8();
@@ -779,7 +783,7 @@ fn shader_equiv_tunnel_vision_strength_1_0_psnr() {
 #[test]
 fn shader_equiv_tunnel_vision_strength_0_5_psnr() {
     let img = color_chart_32();
-    let u = tunnel_vision_uniforms(0.5);
+    let u = tunnel_vision_uniforms(0.5, 32, 32);
     let inner_r = (1.0 - u.strength) * 0.5;
     let outer_r = (inner_r + 0.05_f32).min(1.0);
     let cpu_out = tunnel_vision(img.clone(), 0.5).unwrap().to_rgba8();

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -587,8 +587,6 @@ fn shader_equiv_strength_zero_no_change() {
 /// `inner_r`, `outer_r` を外から渡すことで両方に使用する。
 fn sim_vignette_fov(img: &RgbaImage, strength: f32, inner_r: f32, outer_r: f32) -> RgbaImage {
     let (w, h) = img.dimensions();
-    let cx = w as f32 * 0.5;
-    let cy = h as f32 * 0.5;
     // UV 空間でのコーナー距離: sqrt(0.5^2+0.5^2) = 0.7071...
     let corner_dist = 0.7071067811865476_f32;
     let mut out = img.clone();


### PR DESCRIPTION
## 関連 Issue
closes #46

## 変更内容

視野欠損 4 フィルタの GLSL ES 3.00 シェーダを追加。

### 追加シェーダー
- `glaucoma.frag` — 周辺ビネット（smoothstep マスク）
- `macular_degeneration.frag` — 中心暗化（foveal smoothstep マスク）
- `hemianopia.frag` — 左右半側マスク（uSide: 1.0=右, -1.0=左）
- `tunnel_vision.frag` — 急峻なトンネルビネット

### shaders.rs への追加
各フィルタに `*_glsl()` / `*_uniforms()` を追加。
- `VignetteUniforms { strength: f32 }` — glaucoma / tunnel_vision / macular_degeneration
- `HemianopiaUniforms { strength: f32, side: f32 }` — hemianopia

### テスト追加（8件）
`shader_equivalence.rs` に PSNR ≥ 30 dB テストを各フィルタ strength=0/1 の 2ケースずつ追加。