### PR TITLE
vision: Metamorphopsia（歪視）フィルタ追加 (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **vision: Metamorphopsia（歪視）フィルタを追加** (#55):
+  LCG ベースの 2D グリッドノイズ変位マップで各ピクセルをリマップする `metamorphopsia()` 関数を実装。
+  `strength=0` は byte-exact identity、`strength=1` で最大 8px の変位。双線形補間 + edge clamp。
+  `Filter::Metamorphopsia` を enum に追加し、`apply()` / Pipeline の `apply()` に対応。
+  GLSL シェーダー `metamorphopsia.frag`（hash2D ベースの smooth noise）と `metamorphopsia_glsl()` / `MetamorphopsiaUniforms` / `metamorphopsia_uniforms()` を追加。
+
 - **shader: 視野欠損 4 種の GLSL ES 3.00 シェーダを追加** (#46):
   `glaucoma.frag`（周辺ビネット、smoothstep マスク）、`macular_degeneration.frag`（中心暗化、foveal smoothstep マスク）、`hemianopia.frag`（左右半側マスク）、`tunnel_vision.frag`（急峻なトンネルビネット）の 4 シェーダを `crates/core/src/shaders/` に追加。
   `shaders.rs` に `glaucoma_glsl()` / `macular_degeneration_glsl()` / `hemianopia_glsl()` / `tunnel_vision_glsl()` および対応する uniform 構造体・計算関数を追加。

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -62,6 +62,8 @@ pub enum Filter {
     // vision (Phase 4: eye fatigue / #36)
     EyeStrain,
     DryEye,
+    // vision (Phase N / #55: metamorphopsia)
+    Metamorphopsia,
 }
 
 /// Apply a [`Filter`] to an image at a given strength (`0.0..=1.0`).
@@ -102,6 +104,7 @@ pub fn apply(
         Filter::Starbursts => vision::starbursts(img, strength, 6, 0.1, 0.8),
         Filter::EyeStrain => vision::eye_strain(img, strength),
         Filter::DryEye => vision::dry_eye(img, strength),
+        Filter::Metamorphopsia => vision::metamorphopsia(img, strength, 4.0, 0),
     }
 }
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -40,6 +40,10 @@ pub struct FilterStep {
     pub ray_length_ratio: f32,
     /// starbursts 輝度閾値。デフォルト: 0.8
     pub threshold: f32,
+    /// metamorphopsia 空間周波数。デフォルト: 4.0
+    pub meta_freq: f32,
+    /// metamorphopsia LCG シード。デフォルト: 0
+    pub meta_seed: u64,
 }
 
 impl FilterStep {
@@ -62,6 +66,8 @@ impl FilterStep {
             num_rays: 6,
             ray_length_ratio: 0.1,
             threshold: 0.8,
+            meta_freq: 4.0,
+            meta_seed: 0,
         }
     }
 
@@ -78,6 +84,7 @@ impl FilterStep {
             Filter::Diplopia => vision::diplopia(img, self.strength, self.offset_x, self.offset_y, self.ghost_strength),
             Filter::Nystagmus => vision::nystagmus(img, self.strength, self.amplitude, self.direction_deg),
             Filter::Starbursts => vision::starbursts(img, self.strength, self.num_rays, self.ray_length_ratio, self.threshold),
+            Filter::Metamorphopsia => vision::metamorphopsia(img, self.strength, self.meta_freq, self.meta_seed),
             f => crate::apply(f, img, self.strength),
         }
     }

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -374,6 +374,48 @@ pub fn hemianopia_uniforms(strength: f32, side: f32) -> HemianopiaUniforms {
 }
 
 // ---------------------------------------------------------------------------
+// Metamorphopsia (#55)
+// ---------------------------------------------------------------------------
+
+/// metamorphopsia.frag の GLSL ソースコードを返す。
+pub fn metamorphopsia_glsl() -> &'static str {
+    include_str!("shaders/metamorphopsia.frag")
+}
+
+/// Metamorphopsia シェーダーの uniform 値。
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetamorphopsiaUniforms {
+    /// 歪み強度（0.0..=1.0）
+    pub strength: f32,
+    /// 空間周波数（グリッド分割数）
+    pub freq: f32,
+    /// LCG シード（整数を f32 で渡す）
+    pub seed: f32,
+    /// テクセルサイズ (1/width, 1/height)
+    pub texel_size: [f32; 2],
+}
+
+/// metamorphopsia の uniform を計算する。
+///
+/// `freq`: 空間周波数（グリッド分割数）。
+/// `seed`: LCG シード。
+/// `width`, `height`: 画像サイズ（ピクセル）。
+pub fn metamorphopsia_uniforms(
+    strength: f32,
+    freq: f32,
+    seed: u64,
+    width: u32,
+    height: u32,
+) -> MetamorphopsiaUniforms {
+    MetamorphopsiaUniforms {
+        strength,
+        freq,
+        seed: seed as f32,
+        texel_size: [1.0 / width as f32, 1.0 / height as f32],
+    }
+}
+
+// ---------------------------------------------------------------------------
 // テスト
 // ---------------------------------------------------------------------------
 

--- a/crates/core/src/shaders/metamorphopsia.frag
+++ b/crates/core/src/shaders/metamorphopsia.frag
@@ -1,0 +1,63 @@
+#version 300 es
+precision mediump float;
+
+// 歪視（Metamorphopsia）シミュレーション
+// hash2D ベースの smooth noise 変位マップで各ピクセルをリマップする。
+
+uniform sampler2D uTexture;
+uniform float uStrength;   // 0.0..=1.0
+uniform float uFreq;       // 空間周波数（グリッド分割数 / min(W,H)）
+uniform float uSeed;       // ランダムシード（整数を float で渡す）
+uniform vec2  uTexelSize;  // vec2(1.0/width, 1.0/height)
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+// 2D hash: uv → [0, 1]^2 の擬似ランダム値
+vec2 hash2(vec2 p, float seed) {
+    p += seed * 0.001;
+    p = vec2(
+        dot(p, vec2(127.1, 311.7)),
+        dot(p, vec2(269.5, 183.3))
+    );
+    return fract(sin(p) * 43758.5453123);
+}
+
+// 格子点間を smooth hermite 補間する value noise（変位マップ用）
+vec2 smoothNoise(vec2 uv, float seed) {
+    vec2 i = floor(uv);
+    vec2 f = fract(uv);
+
+    // smoothstep（3次エルミート）
+    vec2 u = f * f * (3.0 - 2.0 * f);
+
+    vec2 a = hash2(i + vec2(0.0, 0.0), seed);
+    vec2 b = hash2(i + vec2(1.0, 0.0), seed);
+    vec2 c = hash2(i + vec2(0.0, 1.0), seed);
+    vec2 d = hash2(i + vec2(1.0, 1.0), seed);
+
+    // 双線形補間
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+void main() {
+    if (uStrength <= 0.0) {
+        fragColor = texture(uTexture, vTexCoord);
+        return;
+    }
+
+    // 最大変位量（テクスチャ座標空間、8px 相当）
+    const float MAX_DISP_PX = 8.0;
+
+    // ノイズ座標（周波数スケール）
+    vec2 noiseUv = vTexCoord * uFreq;
+
+    // [-1, 1]^2 の変位ベクトルを生成
+    vec2 noise = smoothNoise(noiseUv, uSeed) * 2.0 - 1.0;
+
+    // テクスチャ座標への変位量（texel 単位 → uv 単位）
+    vec2 disp = noise * uStrength * MAX_DISP_PX * uTexelSize;
+
+    vec2 sampledUv = clamp(vTexCoord + disp, vec2(0.0), vec2(1.0));
+    fragColor = texture(uTexture, sampledUv);
+}

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2018,6 +2018,136 @@ pub fn eye_strain(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
     Ok(DynamicImage::ImageRgba8(out))
 }
 
+// ---------------------------------------------------------------
+// Phase N (Issue #55): Metamorphopsia — 歪視フィルタ
+// ---------------------------------------------------------------
+
+/// 歪視（Metamorphopsia）シミュレーション。
+///
+/// 黄斑疾患（黄斑円孔・黄斑上膜・加齢黄斑変性など）で生じる格子状の歪み（Amsler grid
+/// 歪曲）を模擬する。LCG ベースのグリッドノイズで各ピクセルを変位座標からサンプリングする。
+///
+/// ## アルゴリズム
+///
+/// 画像を `1/freq` ピクセル単位の仮想グリッドに分割し、各グリッド頂点に
+/// LCG 擬似ランダムな変位ベクトル `(dx, dy)` を割り当てる。
+/// 各出力ピクセルについて、所属するグリッドセルの 4 頂点の変位を双線形補間し、
+/// その変位でサンプリング座標を移動して元画像をサンプリングする。
+/// エッジは clamp で処理する。
+///
+/// 変位量: `strength × MAX_DISPLACEMENT_PX`（最大 8 ピクセル）。
+/// `strength = 0.0` は identity（元画像と byte-exact 一致）。
+///
+/// # 引数
+/// - `img`: 入力画像
+/// - `strength`: 歪み強度（0.0..=1.0）
+/// - `freq`: 空間周波数（グリッドセルサイズ = `max(1, 画像短辺 / freq) px`）
+/// - `seed`: LCG シード（同じ seed なら同じ歪みパターン）
+pub fn metamorphopsia(img: DynamicImage, strength: f32, freq: f32, seed: u64) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    let rgba = img.to_rgba8();
+    if s == 0.0 {
+        return Ok(DynamicImage::ImageRgba8(rgba));
+    }
+
+    let width = rgba.width();
+    let height = rgba.height();
+
+    // 変位幅の最大値（ピクセル）
+    const MAX_DISPLACEMENT_PX: f32 = 8.0;
+    let max_disp = s * MAX_DISPLACEMENT_PX;
+
+    // グリッドセルサイズ（ピクセル単位）。freq が大きいほど細かいグリッド。
+    let min_dim = width.min(height) as f32;
+    let freq_clamped = freq.clamp(0.1, 1000.0);
+    let cell_size = (min_dim / freq_clamped).max(1.0);
+
+    // グリッド頂点数
+    let grid_w = (width as f32 / cell_size).ceil() as usize + 2;
+    let grid_h = (height as f32 / cell_size).ceil() as usize + 2;
+
+    // LCG 定数（Knuth / Numerical Recipes）
+    let lcg_step = |state: u64| -> u64 {
+        state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407)
+    };
+
+    // 各グリッド頂点の変位 (dx, dy) を LCG で生成する。
+    // シードは頂点座標とグローバルシードを混合して決定する（空間的再現性を確保）。
+    let grid_disp: Vec<(f32, f32)> = (0..grid_h)
+        .flat_map(|gy| (0..grid_w).map(move |gx| (gx, gy)))
+        .map(|(gx, gy)| {
+            // 頂点ごとに独立したシードを生成する。
+            // seed との混合で異なる grid_size でもシードが衝突しにくい。
+            let h0 = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let h1 = h0
+                .wrapping_add((gx as u64).wrapping_mul(0x9e3779b97f4a7c15))
+                .wrapping_add((gy as u64).wrapping_mul(0x6c62272e07bb0142));
+            // dx
+            let s1 = lcg_step(h1);
+            let dx_norm = (s1 >> 32) as f32 / u32::MAX as f32; // 0.0..=1.0
+            // dy
+            let s2 = lcg_step(s1);
+            let dy_norm = (s2 >> 32) as f32 / u32::MAX as f32;
+            // [-1, 1] に変換してから max_disp を掛ける
+            let dx = (dx_norm * 2.0 - 1.0) * max_disp;
+            let dy = (dy_norm * 2.0 - 1.0) * max_disp;
+            (dx, dy)
+        })
+        .collect();
+
+    let get_grid = |gx: usize, gy: usize| -> (f32, f32) {
+        let gx = gx.min(grid_w - 1);
+        let gy = gy.min(grid_h - 1);
+        grid_disp[gy * grid_w + gx]
+    };
+
+    // 各出力ピクセルについて変位後座標をサンプリングする。
+    let mut out = image::RgbaImage::new(width, height);
+    for y in 0..height {
+        for x in 0..width {
+            // ピクセルがどのグリッドセルに属するか
+            let fx = x as f32 / cell_size;
+            let fy = y as f32 / cell_size;
+            let gx0 = fx.floor() as usize;
+            let gy0 = fy.floor() as usize;
+            let gx1 = gx0 + 1;
+            let gy1 = gy0 + 1;
+            let tx = fx - fx.floor(); // 0.0..=1.0 のセル内位置
+            let ty = fy - fy.floor();
+
+            // 4 頂点の変位を双線形補間
+            let (d00x, d00y) = get_grid(gx0, gy0);
+            let (d10x, d10y) = get_grid(gx1, gy0);
+            let (d01x, d01y) = get_grid(gx0, gy1);
+            let (d11x, d11y) = get_grid(gx1, gy1);
+
+            let disp_x = d00x * (1.0 - tx) * (1.0 - ty)
+                + d10x * tx * (1.0 - ty)
+                + d01x * (1.0 - tx) * ty
+                + d11x * tx * ty;
+            let disp_y = d00y * (1.0 - tx) * (1.0 - ty)
+                + d10y * tx * (1.0 - ty)
+                + d01y * (1.0 - tx) * ty
+                + d11y * tx * ty;
+
+            // サンプリング座標（clamp でエッジ処理）
+            let src_x = (x as f32 + disp_x)
+                .clamp(0.0, (width - 1) as f32);
+            let src_y = (y as f32 + disp_y)
+                .clamp(0.0, (height - 1) as f32);
+
+            let px = sample_bilinear(&rgba, src_x, src_y);
+            out.put_pixel(x, y, px);
+        }
+    }
+
+    Ok(DynamicImage::ImageRgba8(out))
+}
+
 /// ドライアイ（dry eye）シミュレーション。
 ///
 /// LCG（seed=42 固定）で生成したノイズマスクを基に、
@@ -4425,4 +4555,80 @@ mod tests {
             "eye_strain should reduce contrast: min={min_r} max={max_r}"
         );
     }
+
+    // =================================================================
+    // Issue #55: Metamorphopsia（歪視）テスト
+    // =================================================================
+
+    #[test]
+    fn metamorphopsia_strength_zero_is_identity() {
+        // strength=0 → byte-exact identity（max_err ≤ 1 を許容するが実際は完全一致）
+        let size = 64_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 4) as u8, (y * 4) as u8, 128, 255]);
+        }
+        let orig_raw = img.clone().into_raw();
+        let out = metamorphopsia(DynamicImage::ImageRgba8(img), 0.0, 4.0, 42).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        // strength=0 では byte-exact identity
+        assert_eq!(
+            orig_raw, out_raw,
+            "metamorphopsia strength=0 must be byte-exact identity"
+        );
+    }
+
+    #[test]
+    fn metamorphopsia_strength_one_changes_pixels() {
+        // strength=1 → 少なくとも一部のピクセルが元画像と異なること
+        let size = 64_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 4) as u8, (y * 4) as u8, 100, 255]);
+        }
+        let orig_raw = img.clone().into_raw();
+        let out = metamorphopsia(DynamicImage::ImageRgba8(img), 1.0, 4.0, 42).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        // 少なくとも 1 バイト異なることを確認
+        let differs = orig_raw.iter().zip(out_raw.iter()).any(|(a, b)| a != b);
+        assert!(differs, "metamorphopsia strength=1 must change at least some pixels");
+    }
+
+    #[test]
+    fn metamorphopsia_preserves_image_size() {
+        let img = solid_rgba(48, 32, [200, 100, 50, 255]);
+        let out = metamorphopsia(img, 0.8, 4.0, 123).unwrap();
+        assert_eq!(out.width(), 48);
+        assert_eq!(out.height(), 32);
+    }
+
+    #[test]
+    fn metamorphopsia_preserves_alpha() {
+        // alpha チャンネルは sample_bilinear が保持するので確認
+        let size = 32_u32;
+        let mut img = RgbaImage::new(size, size);
+        for px in img.pixels_mut() {
+            *px = Rgba([128, 64, 32, 200]);
+        }
+        let out = metamorphopsia(DynamicImage::ImageRgba8(img), 1.0, 4.0, 1).unwrap();
+        for px in out.to_rgba8().pixels() {
+            assert_eq!(px[3], 200, "alpha must be preserved through metamorphopsia");
+        }
+    }
+
+    #[test]
+    fn metamorphopsia_different_seeds_give_different_results() {
+        // 異なる seed では異なる歪みパターンになること
+        let size = 64_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 4) as u8, (y * 4) as u8, 100, 255]);
+        }
+        let dyn_img = DynamicImage::ImageRgba8(img);
+        let out1 = metamorphopsia(dyn_img.clone(), 1.0, 4.0, 1).unwrap().to_rgba8().into_raw();
+        let out2 = metamorphopsia(dyn_img, 1.0, 4.0, 99999).unwrap().to_rgba8().into_raw();
+        let differs = out1.iter().zip(out2.iter()).any(|(a, b)| a != b);
+        assert!(differs, "different seeds must produce different distortion patterns");
+    }
 }
+


### PR DESCRIPTION
closes #55

## 概要

Metamorphopsia（歪視）フィルタを実装しました。黄斑疾患（黄斑円孔・黄斑上膜・加齢黄斑変性など）で生じる格子状の歪みを模擬します。

## 実装内容

### Rust 実装 (`vision.rs`)
- `pub fn metamorphopsia(img: DynamicImage, strength: f32, freq: f32, seed: u64) -> Result<DynamicImage>`
- LCG ベースの 2D グリッドノイズ変位マップで各ピクセルをリサンプリング
- グリッド頂点の変位を双線形補間 → edge clamp
- `strength=0` は byte-exact identity

### Filter enum / apply()
- `Filter::Metamorphopsia` を追加
- `lib.rs` の `apply()` にデフォルトパラメータ（freq=4.0, seed=0）で対応
- `pipeline.rs` の `FilterStep` に `meta_freq` / `meta_seed` フィールドを追加

### GLSL シェーダー
- `shaders/metamorphopsia.frag`: hash2D ベースの smooth noise 変位マップ
- `shaders.rs` に `metamorphopsia_glsl()` / `MetamorphopsiaUniforms` / `metamorphopsia_uniforms()` を追加

## テスト（5件追加）
- `metamorphopsia_strength_zero_is_identity` — strength=0 で byte-exact identity
- `metamorphopsia_strength_one_changes_pixels` — strength=1 で少なくとも一部のピクセルが変化
- `metamorphopsia_preserves_image_size` — 出力サイズ保持
- `metamorphopsia_preserves_alpha` — alpha 保持
- `metamorphopsia_different_seeds_give_different_results` — 異なる seed で異なるパターン