### PR TITLE
perf: floaters 距離計算の sqrt 省略 (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **perf: floaters の距離判定で sqrt を省略** (#62):
+  ループ内の `dist = (dx*dx + dy*dy).sqrt()` を除去し、`dist_sq < half_w_sq` による二乗比較に変更。
+  マスク値の計算には依然 `dist_sq.sqrt()` を使用するが、大多数のピクセルはガード条件で早期 skip されるため全体のコストを削減。
+
 ### Added
 
 - **vision: Metamorphopsia（歪視）フィルタを追加** (#55):

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -963,13 +963,14 @@ pub fn floaters(
                 let py0 = ((ly - half_w).floor() as i32 - hw_ceil).max(0);
                 let py1 = ((ly + half_w).ceil() as i32 + hw_ceil).min(height as i32 - 1);
 
+                let half_w_sq = half_w * half_w;
                 for py in py0..=py1 {
                     for ppx in px0..=px1 {
                         let dx = ppx as f32 - lx;
                         let dy = py as f32 - ly;
-                        let dist = (dx * dx + dy * dy).sqrt();
-                        if dist < half_w {
-                            let m = (dist / half_w).clamp(0.0, 1.0);
+                        let dist_sq = dx * dx + dy * dy;
+                        if dist_sq < half_w_sq {
+                            let m = (dist_sq.sqrt() / half_w).clamp(0.0, 1.0);
                             let idx = py as usize * width as usize + ppx as usize;
                             if m < mask_buf[idx] {
                                 mask_buf[idx] = m;


### PR DESCRIPTION
closes #62

## 変更内容

floaters の内部ループで毎ピクセル実行していた sqrt() を省略。

- dist_sq < half_w_sq による二乗比較でガード
- 通過したピクセルのみ dist_sq.sqrt() でマスク値を計算

## テスト結果

cargo test floaters — 7/7 passed