### PR TITLE
test: vertigo/bppv_rotation/vestibular_neuritis の strength=1 効果確認テスト追加 (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `cataract`: ⚠️ 即受診 — 急激な視力低下・視野変化は眼科受診推奨
   - `nyctalopia`: ⚠️ 早期受診 — 夜盲の急激な悪化はビタミンA欠乏・網膜色素変性の可能性
 
+- **test: vertigo / bppv_rotation / vestibular_neuritis の strength=1 効果確認テストを追加** (#60):
+  `vertigo_strength_one_differs_from_input`、`bppv_rotation_strength_one_differs_from_input`、
+  `vestibular_neuritis_strength_one_differs_from_input` の 3 テストを追加。
+  グラデーション画像に strength=1 を適用し、少なくとも 1 ピクセルが変化することを確認する。
+
 - **vision: Metamorphopsia（歪視）フィルタを追加** (#55):
   LCG ベースの 2D グリッドノイズ変位マップで各ピクセルをリマップする `metamorphopsia()` 関数を実装。
   `strength=0` は byte-exact identity、`strength=1` で最大 8px の変位。双線形補間 + edge clamp。

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -4631,5 +4631,53 @@ mod tests {
         let differs = out1.iter().zip(out2.iter()).any(|(a, b)| a != b);
         assert!(differs, "different seeds must produce different distortion patterns");
     }
+
+    // ---------------------------------------------------------------
+    // Issue #60: vertigo / bppv_rotation / vestibular_neuritis テスト
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn vertigo_strength_one_differs_from_input() {
+        // グラデーション画像を使う（均一色だと回転後も同一になるため）
+        let size = 64_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 4) as u8, (y * 4) as u8, 100, 255]);
+        }
+        let orig_raw = img.clone().into_raw();
+        let out = vertigo(DynamicImage::ImageRgba8(img), 1.0, 0.25).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        let differs = orig_raw.iter().zip(out_raw.iter()).any(|(a, b)| a != b);
+        assert!(differs, "vertigo strength=1 must change at least some pixels");
+    }
+
+    #[test]
+    fn bppv_rotation_strength_one_differs_from_input() {
+        let size = 64_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 4) as u8, (y * 4) as u8, 100, 255]);
+        }
+        let orig_raw = img.clone().into_raw();
+        // time_t=0.1 は急速相（angle_norm > 0）
+        let out = bppv_rotation(DynamicImage::ImageRgba8(img), 1.0, 0.1).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        let differs = orig_raw.iter().zip(out_raw.iter()).any(|(a, b)| a != b);
+        assert!(differs, "bppv_rotation strength=1 must change at least some pixels");
+    }
+
+    #[test]
+    fn vestibular_neuritis_strength_one_differs_from_input() {
+        let size = 64_u32;
+        let mut img = RgbaImage::new(size, size);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 4) as u8, (y * 4) as u8, 100, 255]);
+        }
+        let orig_raw = img.clone().into_raw();
+        let out = vestibular_neuritis(DynamicImage::ImageRgba8(img), 1.0).unwrap();
+        let out_raw = out.to_rgba8().into_raw();
+        let differs = orig_raw.iter().zip(out_raw.iter()).any(|(a, b)| a != b);
+        assert!(differs, "vestibular_neuritis strength=1 must change at least some pixels");
+    }
 }
 


### PR DESCRIPTION
closes #60

## 追加テスト

- `vertigo_strength_one_differs_from_input`
- `bppv_rotation_strength_one_differs_from_input`
- `vestibular_neuritis_strength_one_differs_from_input`

グラデーション画像に strength=1 を適用し、少なくとも 1 ピクセルが元画像と異なることを確認する。

## テスト結果

cargo test -- vestibular vertigo bppv — 10/10 passed