### PR TITLE
test: hearing フィルタの strength=1 効果確認テスト追加 (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `vestibular_neuritis_strength_one_differs_from_input` の 3 テストを追加。
   グラデーション画像に strength=1 を適用し、少なくとも 1 ピクセルが変化することを確認する。
 
+- **test: hearing フィルタの strength=1 効果確認テストを追加** (#61):
+  `paracusis_strength_one_differs_from_input`、`dysmelodia_strength_one_differs_from_input`、
+  `amusia_strength_one_differs_from_input` の 3 テストを追加。
+  サイン波入力に strength=1 を適用し、出力 RMS が入力 RMS と有意に異なることを確認する。
+
 - **vision: Metamorphopsia（歪視）フィルタを追加** (#55):
   LCG ベースの 2D グリッドノイズ変位マップで各ピクセルをリマップする `metamorphopsia()` 関数を実装。
   `strength=0` は byte-exact identity、`strength=1` で最大 8px の変位。双線形補間 + edge clamp。

--- a/crates/core/src/hearing.rs
+++ b/crates/core/src/hearing.rs
@@ -869,4 +869,45 @@ mod tests {
         let rms: f32 = (out.samples.iter().map(|&x| x * x).sum::<f32>() / out.samples.len() as f32).sqrt();
         assert!(rms > 0.0, "APD should add noise to silence, rms={rms}");
     }
+
+    // ---------------------------------------------------------------
+    // Issue #61: paracusis / dysmelodia / amusia の strength=1 効果確認
+    // ---------------------------------------------------------------
+
+    fn rms(samples: &[f32]) -> f32 {
+        (samples.iter().map(|&x| x * x).sum::<f32>() / samples.len() as f32).sqrt()
+    }
+
+    #[test]
+    fn paracusis_strength_one_differs_from_input() {
+        // 440 Hz サイン波に paracusis strength=1 を適用すると歪みが加わる
+        let buf = sine_wave(440.0, 44100, 44100);
+        let orig_rms = rms(&buf.samples);
+        let out = paracusis(buf, 1.0);
+        let out_rms = rms(&out.samples);
+        // tanh クリッピングで RMS が変化することを確認（完全一致しないこと）
+        let rel_diff = (out_rms - orig_rms).abs() / orig_rms.max(1e-6);
+        assert!(rel_diff > 0.001, "paracusis strength=1 must alter signal RMS (rel_diff={rel_diff})");
+    }
+
+    #[test]
+    fn dysmelodia_strength_one_differs_from_input() {
+        let buf = sine_wave(440.0, 44100, 44100);
+        let orig_rms = rms(&buf.samples);
+        let out = dysmelodia(buf, 1.0);
+        let out_rms = rms(&out.samples);
+        let rel_diff = (out_rms - orig_rms).abs() / orig_rms.max(1e-6);
+        assert!(rel_diff > 0.001, "dysmelodia strength=1 must alter signal RMS (rel_diff={rel_diff})");
+    }
+
+    #[test]
+    fn amusia_strength_one_differs_from_input() {
+        // 4000 Hz サイン波は 200 Hz カットオフで大きく減衰する
+        let buf = sine_wave(4000.0, 44100, 44100);
+        let orig_rms = rms(&buf.samples);
+        let out = amusia(buf, 1.0);
+        let out_rms = rms(&out.samples);
+        let rel_diff = (out_rms - orig_rms).abs() / orig_rms.max(1e-6);
+        assert!(rel_diff > 0.1, "amusia strength=1 must significantly attenuate 4 kHz signal (rel_diff={rel_diff})");
+    }
 }


### PR DESCRIPTION
closes #61

## 追加テスト

- `paracusis_strength_one_differs_from_input` — tanh ソフトクリッピングで RMS が変化すること
- `dysmelodia_strength_one_differs_from_input` — ハイパス + 歪みで RMS が変化すること
- `amusia_strength_one_differs_from_input` — 200 Hz カットオフで 4 kHz 信号が大幅減衰すること

## テスト結果

cargo test — paracusis/dysmelodia/amusia 合計 6/6 passed (既存 identity 3 + 今回 differs 3)