### PR TITLE
fix: photophobia/nyctalopia/cataract の _uniforms() 関数追加

### DIFF
--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -121,6 +121,28 @@ pub fn cataract_glsl() -> &'static str {
     include_str!("shaders/cataract.frag")
 }
 
+/// photophobia / nyctalopia / cataract の共通 uniform（strength のみ）。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SimpleStrengthUniforms {
+    /// strength (0.0..=1.0)
+    pub strength: f32,
+}
+
+/// photophobia の uniform を返す。
+pub fn photophobia_uniforms(strength: f32) -> SimpleStrengthUniforms {
+    SimpleStrengthUniforms { strength }
+}
+
+/// nyctalopia の uniform を返す。
+pub fn nyctalopia_uniforms(strength: f32) -> SimpleStrengthUniforms {
+    SimpleStrengthUniforms { strength }
+}
+
+/// cataract の uniform を返す。
+pub fn cataract_uniforms(strength: f32) -> SimpleStrengthUniforms {
+    SimpleStrengthUniforms { strength }
+}
+
 /// glaucoma.frag の GLSL ES 3.00 ソースを返す。
 pub fn glaucoma_glsl() -> &'static str {
     include_str!("shaders/glaucoma.frag")


### PR DESCRIPTION
## 概要
`#47` の GLSL シェーダ追加 PR をリベースした際に `--strategy-option=theirs` が shaders.rs の uniforms 追加を上書きしてしまった。
`photophobia_uniforms()` / `nyctalopia_uniforms()` / `cataract_uniforms()` と `SimpleStrengthUniforms` 構造体を追加して修正。

## テスト
`cargo test`: 29 passed
