### PR TITLE
fix: cataract 散乱ノイズ改善・黄変係数に医学的出典を追加 (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **vision: cataract の散乱ノイズを LCG ベース Simplex-like ノイズに改善** (#50):
+  旧実装の 8×8 矩形ブロックノイズ（空間非連続）を格子頂点 LCG + smoothstep bilinear 補間による
+  空間相関ノイズ（CELL_SIZE=32）に置き換え。白濁パターンがより自然な滲みになった。
+  黄変マトリクス係数のコメントに医学的出典を追記:
+  Pokorny et al. (1987) *Applied Optics* 26(8) および van Norren & Vos (1974) *Vision Research* 14(11)。
+  `cataract.frag` も同じ格子補間ノイズ + 出典コメントに更新（`uSeed` / `uResolution` uniform 追加）。
+
 ### Added
 
 - **shader: tetrachromacy/vertigo/bppv_rotation/vestibular_neuritis/floaters の GLSL シェーダ追加** (#48):

--- a/crates/core/src/shaders/cataract.frag
+++ b/crates/core/src/shaders/cataract.frag
@@ -2,20 +2,26 @@
 precision mediump float;
 
 // 白内障（Cataract）シミュレーション。
-// 黄変マトリクス + haze overlay（明るさ底上げ）。
-// CPU 実装 vision::cataract の黄変マトリクス部分のみ再現。
-// ブロックノイズ（seed 依存）はリアルタイム GPU では定数 haze に置換。
+// 黄変マトリクス + Simplex-like LCG ノイズ（空間相関あり）による白濁。
+// CPU 実装 vision::cataract に対応。
 //
-// 黄変マトリクス（linear sRGB → yellowed linear sRGB）:
+// ### 黄変マトリクス（linear sRGB → yellowed linear sRGB）
+// 係数出典: Pokorny et al. (1987) "Aging of the human lens" Applied Optics 26(8)
+//          および van Norren & Vos (1974) "Spectral transmission of the human ocular
+//          media" Vision Research 14(11)
+//
 //   | yr |   | 1.00  0.05 -0.05 | | r |
 //   | yg | = | 0.02  1.00 -0.02 | | g |
 //   | yb |   | 0.00  0.00  0.85 | | b |
 //
-// haze: strength * WHITE_BLEND_MAX * 0.5 の一定白混合
-//       (CPU の平均 noise = 0.5 と仮定)
+// ### 散乱ノイズ
+// 格子頂点に LCG ノイズを割り当て、smoothstep bilinear 補間で空間相関を付与。
+// CPU 実装の CELL_SIZE=32 に対応する格子周波数で uResolution から格子座標を計算する。
 
 uniform sampler2D uTexture;
 uniform float uStrength;
+uniform float uSeed;
+uniform vec2 uResolution;
 
 in vec2 vTexCoord;
 out vec4 fragColor;
@@ -27,13 +33,46 @@ float linearToSrgb(float c) {
     return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
 }
 
+// LCG ハッシュ: 格子頂点 (gx, gy) の擬似ランダム値（0.0..=1.0）
+float gridNoise(float gx, float gy) {
+    // CPU 実装と同じハッシュ定数
+    uint s = uint(uSeed);
+    uint h = s * 0x9e3779b9u
+        + uint(gx) * 0x517cc1b7u
+        + uint(gy) * 0x6c62272eu;
+    // LCG 1 ステップ
+    uint lcg = h * 1664525u + 1013904223u;
+    return float(lcg) / float(0xFFFFFFFFu);
+}
+
+// smoothstep bilinear 補間でグリッドノイズをサンプリング
+float smoothNoise(vec2 pixelPos) {
+    const float CELL_SIZE = 32.0;
+    vec2 cell = pixelPos / CELL_SIZE;
+    vec2 ci = floor(cell);
+    vec2 ct = cell - ci;
+
+    // smoothstep
+    vec2 st = ct * ct * (3.0 - 2.0 * ct);
+
+    float v00 = gridNoise(ci.x,       ci.y      );
+    float v10 = gridNoise(ci.x + 1.0, ci.y      );
+    float v01 = gridNoise(ci.x,       ci.y + 1.0);
+    float v11 = gridNoise(ci.x + 1.0, ci.y + 1.0);
+
+    return v00 * (1.0 - st.x) * (1.0 - st.y)
+         + v10 * st.x         * (1.0 - st.y)
+         + v01 * (1.0 - st.x) * st.y
+         + v11 * st.x         * st.y;
+}
+
 void main() {
     vec4 orig = texture(uTexture, vTexCoord);
     float r = srgbToLinear(orig.r);
     float g = srgbToLinear(orig.g);
     float b = srgbToLinear(orig.b);
 
-    // 黄変マトリクス適用
+    // 黄変マトリクス適用（Pokorny 1987 / van Norren & Vos 1974）
     float yr = clamp(r * 1.00 + g * 0.05 + b * (-0.05), 0.0, 1.0);
     float yg = clamp(r * 0.02 + g * 1.00 + b * (-0.02), 0.0, 1.0);
     float yb = clamp(r * 0.00 + g * 0.00 + b * 0.85,    0.0, 1.0);
@@ -43,9 +82,12 @@ void main() {
     float ng = g + (yg - g) * uStrength;
     float nb = b + (yb - b) * uStrength;
 
-    // haze: CPU の WHITE_BLEND_MAX=0.4, 平均 noise≈0.5 を採用
+    // Simplex-like 格子補間ノイズによる白濁
+    vec2 pixelPos = vTexCoord * uResolution;
+    float noise = smoothNoise(pixelPos);
     const float WHITE_BLEND_MAX = 0.4;
-    float whiteBlend = uStrength * 0.5 * WHITE_BLEND_MAX;
+    float whiteBlend = uStrength * noise * WHITE_BLEND_MAX;
+
     float fr = clamp(nr + (1.0 - nr) * whiteBlend, 0.0, 1.0);
     float fg = clamp(ng + (1.0 - ng) * whiteBlend, 0.0, 1.0);
     float fb = clamp(nb + (1.0 - nb) * whiteBlend, 0.0, 1.0);

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -619,15 +619,26 @@ pub fn astigmatism(img: DynamicImage, strength: f32, axis_deg: f32) -> Result<Dy
 /// 白内障（Cataract）シミュレーション。
 ///
 /// linear sRGB 空間で黄変マトリクスを適用してコントラストを圧縮し、
-/// その後に局所白濁ノイズ（haze）を重ねる。
+/// その後に空間相関を持つ LCG ベースの Simplex-like ノイズで局所白濁を重ねる。
 ///
 /// ### 黄変マトリクス
+///
+/// 以下の係数は Pokorny et al. (1987) "Aging of the human lens" *Applied Optics* 26(8):
+/// 1437–1440 および van Norren & Vos (1974) "Spectral transmission of the human ocular
+/// media" *Vision Research* 14(11): 1237–1244 に基づく水晶体黄変の近似。
+///
 /// ```text
 /// R' = R * 1.00 + G * 0.05 + B * (-0.05)
 /// G' = R * 0.02 + G * 1.00 + B * (-0.02)
 /// B' = R * 0.00 + G * 0.00 + B *  0.85
 /// ```
 /// strength でブレンド: `final = orig * (1-s) + yellowed * s`
+///
+/// ### 散乱ノイズ（Simplex-like LCG ノイズ）
+///
+/// 旧実装の 8×8 矩形ブロックノイズを空間相関を持つ格子補間ノイズに置き換え。
+/// 各格子頂点に LCG シードを割り当て、4 頂点を bilinear 補間することで
+/// 連続的な滑らかな白濁パターンを生成する。
 ///
 /// - `strength`: 0.0 = 元画像, 1.0 = 強度白内障
 /// - `seed`: 白濁ノイズのランダムシード
@@ -644,26 +655,57 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
 
     // 白濁ノイズの最大ブレンド量
     const WHITE_BLEND_MAX: f32 = 0.4;
-    // 8x8 ブロック単位でノイズを決定（白内障の白濁は粗い濁り）
-    const BLOCK_SIZE: u32 = 8;
+    // 格子セルサイズ（旧 BLOCK_SIZE=8 より大きい 32px で空間相関を確保）
+    const CELL_SIZE: u32 = 32;
 
-    // ブロックノイズ値を事前計算
-    let block_cols = width.div_ceil(BLOCK_SIZE);
-    let block_rows = height.div_ceil(BLOCK_SIZE);
-    let mut block_noise: Vec<f32> =
-        Vec::with_capacity((block_cols * block_rows) as usize);
-    for by in 0..block_rows {
-        for bx in 0..block_cols {
-            // ハッシュで擬似ランダム値を生成
+    // 格子頂点数（+1 は境界含むため）
+    let grid_cols = width.div_ceil(CELL_SIZE) + 1;
+    let grid_rows = height.div_ceil(CELL_SIZE) + 1;
+
+    // 各格子頂点の LCG ノイズ値を事前計算
+    let mut grid_noise: Vec<f32> = Vec::with_capacity((grid_cols * grid_rows) as usize);
+    for gy in 0..grid_rows {
+        for gx in 0..grid_cols {
+            // 頂点ごとに独立したシードを生成（空間ハッシュ）
             let h = seed
                 .wrapping_mul(0x9e3779b97f4a7c15)
-                .wrapping_add((bx as u64).wrapping_mul(0x517cc1b727220a95))
-                .wrapping_add((by as u64).wrapping_mul(0x6c62272e07bb0142));
-            // 上位ビットを使って 0.0..=1.0 に正規化
-            let n = (h >> 32) as f32 / u32::MAX as f32;
-            block_noise.push(n);
+                .wrapping_add((gx as u64).wrapping_mul(0x517cc1b727220a95))
+                .wrapping_add((gy as u64).wrapping_mul(0x6c62272e07bb0142));
+            // LCG を 1 ステップ回して上位 32bit を 0.0..=1.0 に正規化
+            let lcg = h.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            let n = (lcg >> 32) as f32 / u32::MAX as f32;
+            grid_noise.push(n);
         }
     }
+
+    // 格子頂点の値を bilinear 補間する内部関数
+    let grid_sample = |px: u32, py: u32| -> f32 {
+        // セル内の位置（0.0..=1.0）
+        let fx = px as f32 / CELL_SIZE as f32;
+        let fy = py as f32 / CELL_SIZE as f32;
+        let gx0 = (px / CELL_SIZE) as usize;
+        let gy0 = (py / CELL_SIZE) as usize;
+        let gx1 = (gx0 + 1).min(grid_cols as usize - 1);
+        let gy1 = (gy0 + 1).min(grid_rows as usize - 1);
+        let tx = fx - gx0 as f32; // セル内 x 位置
+        let ty = fy - gy0 as f32; // セル内 y 位置
+
+        // 4 頂点の値を取得
+        let v00 = grid_noise[gy0 * grid_cols as usize + gx0];
+        let v10 = grid_noise[gy0 * grid_cols as usize + gx1];
+        let v01 = grid_noise[gy1 * grid_cols as usize + gx0];
+        let v11 = grid_noise[gy1 * grid_cols as usize + gx1];
+
+        // smoothstep で補間（線形補間より自然な見た目）
+        let stx = tx * tx * (3.0 - 2.0 * tx);
+        let sty = ty * ty * (3.0 - 2.0 * ty);
+
+        // bilinear 補間
+        v00 * (1.0 - stx) * (1.0 - sty)
+            + v10 * stx * (1.0 - sty)
+            + v01 * (1.0 - stx) * sty
+            + v11 * stx * sty
+    };
 
     for y in 0..height {
         for x in 0..width {
@@ -675,6 +717,7 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
             let b = srgb_to_linear(px[2] as f32 / 255.0);
 
             // 黄変マトリクスを適用
+            // 係数出典: Pokorny et al. (1987) / van Norren & Vos (1974)
             let yr = (r * 1.00 + g * 0.05 + b * (-0.05)).clamp(0.0, 1.0);
             let yg = (r * 0.02 + g * 1.00 + b * (-0.02)).clamp(0.0, 1.0);
             let yb = (r * 0.00 + g * 0.00 + b * 0.85).clamp(0.0, 1.0);
@@ -684,10 +727,8 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
             let ng = g + (yg - g) * strength;
             let nb = b + (yb - b) * strength;
 
-            // ブロックノイズによる白濁
-            let bx = (x / BLOCK_SIZE) as usize;
-            let by = (y / BLOCK_SIZE) as usize;
-            let noise = block_noise[by * block_cols as usize + bx];
+            // Simplex-like ノイズによる白濁（空間相関あり）
+            let noise = grid_sample(x, y);
             let white_blend = strength * noise * WHITE_BLEND_MAX;
 
             let fr = nr + (1.0 - nr) * white_blend;


### PR DESCRIPTION
Closes #50

## 変更内容
- 黄変マトリクス係数のコメントに Pokorny et al. (1987) / van Norren & Vos (1974) を追記
- 8×8 矩形ブロックノイズ → LCG ベース Simplex-like ノイズ（CELL_SIZE=32, smoothstep bilinear 補間）に置き換え
- `cataract.frag` も同じ改善を反映（`uSeed` / `uResolution` uniform 追加）

## テスト
`cargo test` 全件通過