### PR TITLE
feat: vision: Contrast Sensitivity フィルタ追加 (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **vision: Contrast Sensitivity フィルタ追加** (#56):
+  `contrast_sensitivity(img, strength)` を `vision.rs` に追加。
+  輝度コントラストを linear sRGB 空間で midpoint (0.5) に引き寄せる。
+  式: `output = 0.5 + (input − 0.5) × (1.0 − strength × 0.5)`。
+  `strength=0` で identity、`strength=1` で 50% コントラスト圧縮。
+  `Filter::ContrastSensitivity` を `lib.rs` に追加。
+  `contrast_sensitivity.frag` GLSL シェーダ追加。
+  テスト: strength=0 → PSNR ≥ 60 dB、strength=1 → 輝度分散が入力より小さいこと。
+
 ### Fixed
 
 - **vision: cataract の散乱ノイズを LCG ベース Simplex-like ノイズに改善** (#50):

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -64,6 +64,8 @@ pub enum Filter {
     DryEye,
     // vision (Phase N / #55: metamorphopsia)
     Metamorphopsia,
+    // vision (Phase N / #56: contrast sensitivity)
+    ContrastSensitivity,
 }
 
 /// Apply a [`Filter`] to an image at a given strength (`0.0..=1.0`).
@@ -105,6 +107,7 @@ pub fn apply(
         Filter::EyeStrain => vision::eye_strain(img, strength),
         Filter::DryEye => vision::dry_eye(img, strength),
         Filter::Metamorphopsia => vision::metamorphopsia(img, strength, 4.0, 0),
+        Filter::ContrastSensitivity => vision::contrast_sensitivity(img, strength),
     }
 }
 

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -106,6 +106,16 @@ pub fn dry_eye_glsl() -> &'static str {
     include_str!("shaders/dry_eye.frag")
 }
 
+/// contrast_sensitivity.frag の GLSL ES 3.00 ソースを返す。
+pub fn contrast_sensitivity_glsl() -> &'static str {
+    include_str!("shaders/contrast_sensitivity.frag")
+}
+
+/// contrast_sensitivity の uniform を返す。
+pub fn contrast_sensitivity_uniforms(strength: f32) -> SimpleStrengthUniforms {
+    SimpleStrengthUniforms { strength }
+}
+
 /// photophobia.frag の GLSL ES 3.00 ソースを返す。
 pub fn photophobia_glsl() -> &'static str {
     include_str!("shaders/photophobia.frag")

--- a/crates/core/src/shaders/contrast_sensitivity.frag
+++ b/crates/core/src/shaders/contrast_sensitivity.frag
@@ -1,0 +1,24 @@
+#version 300 es
+precision mediump float;
+uniform sampler2D u_image;
+uniform float u_strength;
+in vec2 v_texcoord;
+out vec4 out_color;
+
+// sRGB -> linear
+float srgb_to_linear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+// linear -> sRGB
+float linear_to_srgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 c = texture(u_image, v_texcoord);
+    vec3 lin = vec3(srgb_to_linear(c.r), srgb_to_linear(c.g), srgb_to_linear(c.b));
+    // output = 0.5 + (input - 0.5) * (1.0 - strength * 0.5)
+    float scale = 1.0 - u_strength * 0.5;
+    vec3 result = clamp(vec3(0.5) + (lin - vec3(0.5)) * scale, 0.0, 1.0);
+    out_color = vec4(linear_to_srgb(result.r), linear_to_srgb(result.g), linear_to_srgb(result.b), c.a);
+}

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2409,6 +2409,41 @@ pub fn dry_eye(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
     Ok(DynamicImage::ImageRgba8(out))
 }
 
+// ---------------------------------------------------------------
+// Issue #56: Contrast Sensitivity フィルタ
+// ---------------------------------------------------------------
+
+/// コントラスト感度低下（Contrast Sensitivity Loss）シミュレーション。
+///
+/// 輝度コントラストを圧縮し、midpoint (0.5) に引き寄せる。
+/// 式: `output = 0.5 + (input - 0.5) * (1.0 - strength * 0.5)`
+///
+/// - `strength = 0.0`: 元画像と同一
+/// - `strength = 1.0`: 輝度コントラストを 50% 圧縮
+///
+/// 処理は linear sRGB 空間で行う。
+pub fn contrast_sensitivity(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    let mut rgba = img.to_rgba8();
+    if s == 0.0 {
+        return Ok(DynamicImage::ImageRgba8(rgba));
+    }
+    let scale = 1.0 - s * 0.5;
+    for px in rgba.pixels_mut() {
+        let r = srgb_to_linear(px[0] as f32 / 255.0);
+        let g = srgb_to_linear(px[1] as f32 / 255.0);
+        let b = srgb_to_linear(px[2] as f32 / 255.0);
+        let nr = 0.5 + (r - 0.5) * scale;
+        let ng = 0.5 + (g - 0.5) * scale;
+        let nb = 0.5 + (b - 0.5) * scale;
+        px[0] = pack_u8(linear_to_srgb(nr.clamp(0.0, 1.0)));
+        px[1] = pack_u8(linear_to_srgb(ng.clamp(0.0, 1.0)));
+        px[2] = pack_u8(linear_to_srgb(nb.clamp(0.0, 1.0)));
+        // alpha はそのまま
+    }
+    Ok(DynamicImage::ImageRgba8(rgba))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4970,6 +5005,54 @@ mod tests {
         let out = glaucoma(DynamicImage::ImageRgba8(img), 1.0, GlaucomaMode::Biarcuate).unwrap();
         let out_sum: u32 = out.to_rgba8().pixels().map(|p| p[0] as u32 + p[1] as u32 + p[2] as u32).sum();
         assert!(out_sum < orig_sum, "glaucoma Biarcuate strength=1 must darken");
+    }
+
+    // -------------------------------------------------------
+    // contrast_sensitivity tests
+    // -------------------------------------------------------
+
+    #[test]
+    fn contrast_sensitivity_strength_zero_identity() {
+        let mut img = RgbaImage::new(64, 64);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 3 + y * 7) as u8, (y * 4) as u8, 128, 255]);
+        }
+        let orig = img.clone();
+        let out = contrast_sensitivity(DynamicImage::ImageRgba8(img), 0.0).unwrap().to_rgba8();
+        // PSNR >= 60 dB
+        let mse: f64 = orig.pixels().zip(out.pixels()).map(|(a, b)| {
+            (0..3).map(|i| {
+                let d = a[i] as f64 - b[i] as f64;
+                d * d
+            }).sum::<f64>()
+        }).sum::<f64>() / (64.0 * 64.0 * 3.0);
+        if mse > 0.0 {
+            let psnr = 10.0 * (255.0_f64 * 255.0 / mse).log10();
+            assert!(psnr >= 60.0, "PSNR={psnr:.1} dB, expected >= 60 dB");
+        }
+    }
+
+    #[test]
+    fn contrast_sensitivity_strength_one_reduces_variance() {
+        let mut img = RgbaImage::new(64, 64);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 4) as u8, (y * 4) as u8, 128, 255]);
+        }
+        let orig = img.clone();
+        let out = contrast_sensitivity(DynamicImage::ImageRgba8(img), 1.0).unwrap().to_rgba8();
+
+        let luma = |p: &image::Rgba<u8>| -> f64 {
+            0.2126 * p[0] as f64 + 0.7152 * p[1] as f64 + 0.0722 * p[2] as f64
+        };
+        let variance = |pixels: &RgbaImage| -> f64 {
+            let vals: Vec<f64> = pixels.pixels().map(luma).collect();
+            let mean = vals.iter().sum::<f64>() / vals.len() as f64;
+            vals.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / vals.len() as f64
+        };
+
+        let var_in = variance(&orig);
+        let var_out = variance(&out);
+        assert!(var_out < var_in, "contrast_sensitivity strength=1 must reduce luminance variance (in={var_in:.2}, out={var_out:.2})");
     }
 }
 

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -957,3 +957,9 @@ fn shader_floaters_glsl_is_not_empty() {
     use sensus_core::shaders::floaters_glsl;
     assert!(!floaters_glsl().is_empty());
 }
+
+#[test]
+fn shader_contrast_sensitivity_glsl_is_not_empty() {
+    use sensus_core::shaders::contrast_sensitivity_glsl;
+    assert!(!contrast_sensitivity_glsl().is_empty());
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -73,7 +73,7 @@ fn filter(img: DynamicImage, /* filter-specific params */, strength: f32) -> Dyn
 
 | Module | Phase | Issues | Filters |
 |---|---|---|---|
-| `vision` | 1–5 | #2, #3, #4, #5, #6, #19, #29, #36, #37 | color vision deficiency, tetrachromacy, refraction, visual field defects, light / transparency, depth-aware blur, diplopia, nystagmus, starbursts, eye_strain, dry_eye |
+| `vision` | 1–5 | #2, #3, #4, #5, #6, #19, #29, #36, #37, #56 | color vision deficiency, tetrachromacy, refraction, visual field defects, light / transparency, depth-aware blur, diplopia, nystagmus, starbursts, eye_strain, dry_eye, contrast_sensitivity |
 | `hearing` | 4 | #7, #8, #9 | hearing loss, pitch shift, balance / vertigo |
 | `stereo` | 6 | #31, #32 | MPO stereo photography → depth map (`split_mpo`, `stereo_to_depth`); Android XMP Depth extraction (`read_xmp_depth`) |
 | `pipeline` | 4 | #10 | filter composition ✅ |
@@ -115,6 +115,16 @@ let result = Pipeline::new()
   making processing O(tile_area × kernel_height) instead of O(W×H × kernel_height).
   Because the blur radius varies spatially per tile with a fixed seed, this
   filter is not amenable to a GLSL equivalence test.
+
+## Contrast Sensitivity filter (#56)
+
+`contrast_sensitivity(img, strength)` compresses luminance contrast toward the
+midpoint (0.5) in linear sRGB space.
+
+Formula: `output = 0.5 + (input − 0.5) × (1.0 − strength × 0.5)`
+
+- `strength = 0.0` → identity (same as source image)
+- `strength = 1.0` → 50% contrast compression (output luminance variance < input)
 
 ## Auditory Processing Disorder (APD) (Issue #38)
 


### PR DESCRIPTION
closes #56

## 変更内容
- `contrast_sensitivity(img, strength)` を `vision.rs` に追加
- 式: `output = 0.5 + (input − 0.5) × (1.0 − strength × 0.5)`
- `Filter::ContrastSensitivity` を `lib.rs` に追加
- `contrast_sensitivity.frag` GLSL シェーダ追加
- テスト: strength=0 → PSNR ≥ 60 dB、strength=1 → 輝度分散が入力より小さいこと

cargo test: 296 passed