### PR TITLE
feat: vision: Detail Loss フィルタ追加 (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **vision: Detail Loss フィルタ追加** (#57):
+  `detail_loss(img, strength)` を `vision.rs` に追加。矩形タイルごとに平均色に置き換える（pixelation）。
+  タイルサイズ = `(strength × 20.0).max(1.0) as u32` px（strength=1 で 20px タイル）。
+  `strength=0` で identity、`strength=1` で標準偏差が入力より低くなること。
+  `Filter::DetailLoss` を `lib.rs` に追加。
+  `detail_loss.frag` GLSL シェーダ追加。
+  テスト: strength=0 → identity、strength=1 → 輝度標準偏差が入力より低いこと。
+
 - **vision: Contrast Sensitivity フィルタ追加** (#56):
   `contrast_sensitivity(img, strength)` を `vision.rs` に追加。
   輝度コントラストを linear sRGB 空間で midpoint (0.5) に引き寄せる。

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -66,6 +66,8 @@ pub enum Filter {
     Metamorphopsia,
     // vision (Phase N / #56: contrast sensitivity)
     ContrastSensitivity,
+    // vision (Phase N / #57: detail loss)
+    DetailLoss,
 }
 
 /// Apply a [`Filter`] to an image at a given strength (`0.0..=1.0`).
@@ -108,6 +110,7 @@ pub fn apply(
         Filter::DryEye => vision::dry_eye(img, strength),
         Filter::Metamorphopsia => vision::metamorphopsia(img, strength, 4.0, 0),
         Filter::ContrastSensitivity => vision::contrast_sensitivity(img, strength),
+        Filter::DetailLoss => vision::detail_loss(img, strength),
     }
 }
 

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -116,6 +116,16 @@ pub fn contrast_sensitivity_uniforms(strength: f32) -> SimpleStrengthUniforms {
     SimpleStrengthUniforms { strength }
 }
 
+/// detail_loss.frag の GLSL ES 3.00 ソースを返す。
+pub fn detail_loss_glsl() -> &'static str {
+    include_str!("shaders/detail_loss.frag")
+}
+
+/// detail_loss の uniform を返す。
+pub fn detail_loss_uniforms(strength: f32) -> SimpleStrengthUniforms {
+    SimpleStrengthUniforms { strength }
+}
+
 /// photophobia.frag の GLSL ES 3.00 ソースを返す。
 pub fn photophobia_glsl() -> &'static str {
     include_str!("shaders/photophobia.frag")

--- a/crates/core/src/shaders/detail_loss.frag
+++ b/crates/core/src/shaders/detail_loss.frag
@@ -1,0 +1,30 @@
+#version 300 es
+precision mediump float;
+uniform sampler2D u_image;
+uniform float u_strength;
+uniform vec2 u_resolution;
+in vec2 v_texcoord;
+out vec4 out_color;
+
+// sRGB -> linear
+float srgb_to_linear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+// linear -> sRGB
+float linear_to_srgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    // tile_size = (strength * 20.0).max(1.0)
+    float tile_size = max(u_strength * 20.0, 1.0);
+
+    // UV をタイル境界にスナップ
+    vec2 px = v_texcoord * u_resolution;
+    vec2 tile_origin = floor(px / tile_size) * tile_size;
+    vec2 snapped_uv = (tile_origin + tile_size * 0.5) / u_resolution;
+    snapped_uv = clamp(snapped_uv, 0.0, 1.0);
+
+    vec4 c = texture(u_image, snapped_uv);
+    out_color = c;
+}

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2444,6 +2444,71 @@ pub fn contrast_sensitivity(img: DynamicImage, strength: f32) -> Result<DynamicI
     Ok(DynamicImage::ImageRgba8(rgba))
 }
 
+// ---------------------------------------------------------------
+// Issue #57: Detail Loss フィルタ（pixelation）
+// ---------------------------------------------------------------
+
+/// 細部喪失（Detail Loss）シミュレーション。
+///
+/// 矩形タイルごとに平均色に置き換える（pixelation）。
+/// タイルサイズ = `(strength * 20.0).max(1.0) as u32` px。
+///
+/// - `strength = 0.0`: identity（タイルサイズ 1px = 変化なし）
+/// - `strength = 1.0`: 20px タイル
+pub fn detail_loss(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    let rgba = img.to_rgba8();
+    let tile_size = (s * 20.0).max(1.0) as u32;
+    if tile_size <= 1 {
+        return Ok(DynamicImage::ImageRgba8(rgba));
+    }
+    let width = rgba.width();
+    let height = rgba.height();
+    let mut out = rgba.clone();
+
+    let tile_cols = width.div_ceil(tile_size);
+    let tile_rows = height.div_ceil(tile_size);
+
+    for ty in 0..tile_rows {
+        for tx in 0..tile_cols {
+            let x0 = tx * tile_size;
+            let y0 = ty * tile_size;
+            let x1 = (x0 + tile_size).min(width);
+            let y1 = (y0 + tile_size).min(height);
+            let count = ((x1 - x0) * (y1 - y0)) as u64;
+            if count == 0 {
+                continue;
+            }
+
+            // タイル内の平均色を linear sRGB で計算
+            let mut sum = [0.0_f64; 3];
+            for py in y0..y1 {
+                for px in x0..x1 {
+                    let p = rgba.get_pixel(px, py);
+                    sum[0] += srgb_to_linear(p[0] as f32 / 255.0) as f64;
+                    sum[1] += srgb_to_linear(p[1] as f32 / 255.0) as f64;
+                    sum[2] += srgb_to_linear(p[2] as f32 / 255.0) as f64;
+                }
+            }
+            let avg_r = pack_u8(linear_to_srgb((sum[0] / count as f64) as f32));
+            let avg_g = pack_u8(linear_to_srgb((sum[1] / count as f64) as f32));
+            let avg_b = pack_u8(linear_to_srgb((sum[2] / count as f64) as f32));
+
+            for py in y0..y1 {
+                for px in x0..x1 {
+                    let p = out.get_pixel_mut(px, py);
+                    p[0] = avg_r;
+                    p[1] = avg_g;
+                    p[2] = avg_b;
+                    // alpha はそのまま
+                }
+            }
+        }
+    }
+
+    Ok(DynamicImage::ImageRgba8(out))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5053,6 +5118,44 @@ mod tests {
         let var_in = variance(&orig);
         let var_out = variance(&out);
         assert!(var_out < var_in, "contrast_sensitivity strength=1 must reduce luminance variance (in={var_in:.2}, out={var_out:.2})");
+    }
+
+    // -------------------------------------------------------
+    // detail_loss tests
+    // -------------------------------------------------------
+
+    #[test]
+    fn detail_loss_strength_zero_identity() {
+        let mut img = RgbaImage::new(64, 64);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 3 + y * 7) as u8, (y * 4) as u8, 128, 255]);
+        }
+        let orig = img.clone().into_raw();
+        let out = detail_loss(DynamicImage::ImageRgba8(img), 0.0).unwrap().to_rgba8().into_raw();
+        assert_eq!(orig, out, "detail_loss strength=0 must be identity");
+    }
+
+    #[test]
+    fn detail_loss_strength_one_reduces_stddev() {
+        let mut img = RgbaImage::new(64, 64);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 4) as u8, (y * 4) as u8, 128, 255]);
+        }
+        let orig = img.clone();
+        let out = detail_loss(DynamicImage::ImageRgba8(img), 1.0).unwrap().to_rgba8();
+
+        let luma = |p: &image::Rgba<u8>| -> f64 {
+            0.2126 * p[0] as f64 + 0.7152 * p[1] as f64 + 0.0722 * p[2] as f64
+        };
+        let stddev = |pixels: &RgbaImage| -> f64 {
+            let vals: Vec<f64> = pixels.pixels().map(luma).collect();
+            let mean = vals.iter().sum::<f64>() / vals.len() as f64;
+            (vals.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / vals.len() as f64).sqrt()
+        };
+
+        let sd_in = stddev(&orig);
+        let sd_out = stddev(&out);
+        assert!(sd_out < sd_in, "detail_loss strength=1 must reduce stddev (in={sd_in:.2}, out={sd_out:.2})");
     }
 }
 

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -963,3 +963,9 @@ fn shader_contrast_sensitivity_glsl_is_not_empty() {
     use sensus_core::shaders::contrast_sensitivity_glsl;
     assert!(!contrast_sensitivity_glsl().is_empty());
 }
+
+#[test]
+fn shader_detail_loss_glsl_is_not_empty() {
+    use sensus_core::shaders::detail_loss_glsl;
+    assert!(!detail_loss_glsl().is_empty());
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -73,7 +73,7 @@ fn filter(img: DynamicImage, /* filter-specific params */, strength: f32) -> Dyn
 
 | Module | Phase | Issues | Filters |
 |---|---|---|---|
-| `vision` | 1–5 | #2, #3, #4, #5, #6, #19, #29, #36, #37, #56 | color vision deficiency, tetrachromacy, refraction, visual field defects, light / transparency, depth-aware blur, diplopia, nystagmus, starbursts, eye_strain, dry_eye, contrast_sensitivity |
+| `vision` | 1–5 | #2, #3, #4, #5, #6, #19, #29, #36, #37, #56, #57 | color vision deficiency, tetrachromacy, refraction, visual field defects, light / transparency, depth-aware blur, diplopia, nystagmus, starbursts, eye_strain, dry_eye, contrast_sensitivity, detail_loss |
 | `hearing` | 4 | #7, #8, #9 | hearing loss, pitch shift, balance / vertigo |
 | `stereo` | 6 | #31, #32 | MPO stereo photography → depth map (`split_mpo`, `stereo_to_depth`); Android XMP Depth extraction (`read_xmp_depth`) |
 | `pipeline` | 4 | #10 | filter composition ✅ |


### PR DESCRIPTION
closes #57

## 変更内容
- `detail_loss(img, strength)` を `vision.rs` に追加（矩形タイル pixelation）
- タイルサイズ = `(strength × 20.0).max(1.0) as u32` px
- `Filter::DetailLoss` を `lib.rs` に追加
- `detail_loss.frag` GLSL シェーダ追加
- テスト: strength=0 → identity、strength=1 → 輝度標準偏差が入力より低いこと

cargo test: 299 passed