### PR TITLE
feat: vision: Teichopsia フィルタ追加 (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **vision: Teichopsia フィルタ追加** (#58):
+  `teichopsia(img, strength)` を `vision.rs` に追加。視野周辺にジグザグ縞の光（要塞スペクトル）を重畳し、
+  内側（scotoma）を暗化する。リング領域（正規化距離 0.2〜0.5）で saw wave 輝度加算、
+  内側（< 0.2）を `strength × 0.7` で暗化。`Filter::Teichopsia` を `lib.rs` に追加。
+  `teichopsia.frag` GLSL シェーダ追加。
+  `docs/overview.md` に医学的注記追加:「偏頭痛の前兆として 20〜30 分続く。初めて経験する場合は眼科・神経内科を受診。」
+  テスト: strength=0 → PSNR ≥ 60 dB、strength=1 → 画像中心が暗化。
+
 - **vision: Detail Loss フィルタ追加** (#57):
   `detail_loss(img, strength)` を `vision.rs` に追加。矩形タイルごとに平均色に置き換える（pixelation）。
   タイルサイズ = `(strength × 20.0).max(1.0) as u32` px（strength=1 で 20px タイル）。

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -68,6 +68,8 @@ pub enum Filter {
     ContrastSensitivity,
     // vision (Phase N / #57: detail loss)
     DetailLoss,
+    // vision (Phase N / #58: teichopsia)
+    Teichopsia,
 }
 
 /// Apply a [`Filter`] to an image at a given strength (`0.0..=1.0`).
@@ -111,6 +113,7 @@ pub fn apply(
         Filter::Metamorphopsia => vision::metamorphopsia(img, strength, 4.0, 0),
         Filter::ContrastSensitivity => vision::contrast_sensitivity(img, strength),
         Filter::DetailLoss => vision::detail_loss(img, strength),
+        Filter::Teichopsia => vision::teichopsia(img, strength),
     }
 }
 

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -126,6 +126,16 @@ pub fn detail_loss_uniforms(strength: f32) -> SimpleStrengthUniforms {
     SimpleStrengthUniforms { strength }
 }
 
+/// teichopsia.frag の GLSL ES 3.00 ソースを返す。
+pub fn teichopsia_glsl() -> &'static str {
+    include_str!("shaders/teichopsia.frag")
+}
+
+/// teichopsia の uniform を返す。
+pub fn teichopsia_uniforms(strength: f32) -> SimpleStrengthUniforms {
+    SimpleStrengthUniforms { strength }
+}
+
 /// photophobia.frag の GLSL ES 3.00 ソースを返す。
 pub fn photophobia_glsl() -> &'static str {
     include_str!("shaders/photophobia.frag")

--- a/crates/core/src/shaders/teichopsia.frag
+++ b/crates/core/src/shaders/teichopsia.frag
@@ -1,0 +1,44 @@
+#version 300 es
+precision mediump float;
+uniform sampler2D u_image;
+uniform float u_strength;
+in vec2 v_texcoord;
+out vec4 out_color;
+
+#define PI 3.14159265358979323846
+
+// sRGB -> linear
+float srgb_to_linear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+// linear -> sRGB
+float linear_to_srgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 c = texture(u_image, v_texcoord);
+    vec3 lin = vec3(srgb_to_linear(c.r), srgb_to_linear(c.g), srgb_to_linear(c.b));
+
+    // 正規化 UV (-0.5..0.5)
+    vec2 uv = v_texcoord - vec2(0.5);
+    float dist = length(uv);
+
+    vec3 result = lin;
+
+    if (dist < 0.2) {
+        // scotoma: 内側を暗化
+        float dark = 1.0 - u_strength * 0.7 * (1.0 - dist / 0.2);
+        result = lin * dark;
+    } else if (dist <= 0.5) {
+        // ジグザグリング: saw wave
+        float angle = atan(uv.y, uv.x);
+        float saw = fract(angle / PI * 8.0);
+        float ring_t = (dist - 0.2) / 0.3;
+        float fade = clamp(ring_t * (1.0 - ring_t) * 4.0, 0.0, 1.0);
+        float brightness = saw * u_strength * fade * 0.6;
+        result = clamp(lin + vec3(brightness), 0.0, 1.0);
+    }
+
+    out_color = vec4(linear_to_srgb(result.r), linear_to_srgb(result.g), linear_to_srgb(result.b), c.a);
+}

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2509,6 +2509,78 @@ pub fn detail_loss(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
     Ok(DynamicImage::ImageRgba8(out))
 }
 
+// ---------------------------------------------------------------
+// Issue #58: Teichopsia フィルタ（偏頭痛の前兆：要塞スペクトル）
+// ---------------------------------------------------------------
+
+/// 閃輝暗点（Teichopsia / Fortification Spectra）シミュレーション。
+///
+/// 視野周辺にジグザグ縞の光（要塞スペクトル）を重畳し、内側（scotoma）を暗化する。
+///
+/// ## アルゴリズム
+///
+/// 1. 正規化 UV 座標（-0.5..0.5）で中心からの距離を計算
+/// 2. 距離 0.2〜0.5 のリング領域内でジグザグ輝度を加算（saw wave）
+/// 3. 内側（< 0.2）は scotoma として暗化
+/// 4. strength でリング輝度と scotoma 暗化をスケール
+///
+/// > **医学的注記**: 偏頭痛の前兆として 20〜30 分続く。
+/// > 初めて経験する場合は眼科・神経内科を受診。
+///
+/// - `strength = 0.0`: 元画像と同一
+/// - `strength = 1.0`: 最大の閃輝暗点効果
+pub fn teichopsia(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    let mut rgba = img.to_rgba8();
+    if s == 0.0 {
+        return Ok(DynamicImage::ImageRgba8(rgba));
+    }
+    let width = rgba.width();
+    let height = rgba.height();
+    let w_f = width as f32;
+    let h_f = height as f32;
+    let aspect = w_f / h_f;
+
+    for y in 0..height {
+        for x in 0..width {
+            // 正規化座標（-0.5..0.5）
+            let ux = (x as f32 / w_f) - 0.5;
+            let uy = ((y as f32 / h_f) - 0.5) / aspect;
+            let dist = (ux * ux + uy * uy).sqrt();
+
+            let px = rgba.get_pixel_mut(x, y);
+
+            if dist < 0.2 {
+                // scotoma: 内側を strength に応じて暗化
+                let dark = 1.0 - s * 0.7 * (1.0 - dist / 0.2);
+                let rl = srgb_to_linear(px[0] as f32 / 255.0);
+                let gl = srgb_to_linear(px[1] as f32 / 255.0);
+                let bl = srgb_to_linear(px[2] as f32 / 255.0);
+                px[0] = pack_u8(linear_to_srgb(rl * dark));
+                px[1] = pack_u8(linear_to_srgb(gl * dark));
+                px[2] = pack_u8(linear_to_srgb(bl * dark));
+            } else if dist >= 0.2 && dist <= 0.5 {
+                // ジグザグリング
+                let angle = uy.atan2(ux);
+                let saw = (angle / PI * 8.0).fract(); // saw wave 0..1
+                let ring_t = (dist - 0.2) / 0.3; // 0..1 in ring
+                let fade = (ring_t * (1.0 - ring_t) * 4.0).clamp(0.0, 1.0); // 中央強調
+                let brightness = saw * s * fade * 0.6;
+
+                let rl = srgb_to_linear(px[0] as f32 / 255.0);
+                let gl = srgb_to_linear(px[1] as f32 / 255.0);
+                let bl = srgb_to_linear(px[2] as f32 / 255.0);
+                px[0] = pack_u8(linear_to_srgb((rl + brightness).min(1.0)));
+                px[1] = pack_u8(linear_to_srgb((gl + brightness).min(1.0)));
+                px[2] = pack_u8(linear_to_srgb((bl + brightness).min(1.0)));
+            }
+            // 外側は変更なし
+        }
+    }
+
+    Ok(DynamicImage::ImageRgba8(rgba))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5156,6 +5228,41 @@ mod tests {
         let sd_in = stddev(&orig);
         let sd_out = stddev(&out);
         assert!(sd_out < sd_in, "detail_loss strength=1 must reduce stddev (in={sd_in:.2}, out={sd_out:.2})");
+    }
+
+    // -------------------------------------------------------
+    // teichopsia tests
+    // -------------------------------------------------------
+
+    #[test]
+    fn teichopsia_strength_zero_identity() {
+        let mut img = RgbaImage::new(64, 64);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 3 + y * 7) as u8, (y * 4) as u8, 128, 255]);
+        }
+        let orig = img.clone();
+        let out = teichopsia(DynamicImage::ImageRgba8(img), 0.0).unwrap().to_rgba8();
+        // PSNR >= 60 dB
+        let mse: f64 = orig.pixels().zip(out.pixels()).map(|(a, b)| {
+            (0..3).map(|i| { let d = a[i] as f64 - b[i] as f64; d * d }).sum::<f64>()
+        }).sum::<f64>() / (64.0 * 64.0 * 3.0);
+        if mse > 0.0 {
+            let psnr = 10.0 * (255.0_f64 * 255.0 / mse).log10();
+            assert!(psnr >= 60.0, "PSNR={psnr:.1} dB expected >= 60 dB");
+        }
+    }
+
+    #[test]
+    fn teichopsia_strength_one_darkens_center() {
+        let mut img = RgbaImage::new(64, 64);
+        for px in img.pixels_mut() {
+            *px = Rgba([200, 200, 200, 255]);
+        }
+        let out = teichopsia(DynamicImage::ImageRgba8(img), 1.0).unwrap().to_rgba8();
+        // 中心ピクセル（scotoma）が暗化されているか
+        let center = out.get_pixel(32, 32);
+        let brightness = center[0] as u32 + center[1] as u32 + center[2] as u32;
+        assert!(brightness < 600, "teichopsia strength=1 must darken center (got {brightness})");
     }
 }
 

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -969,3 +969,9 @@ fn shader_detail_loss_glsl_is_not_empty() {
     use sensus_core::shaders::detail_loss_glsl;
     assert!(!detail_loss_glsl().is_empty());
 }
+
+#[test]
+fn shader_teichopsia_glsl_is_not_empty() {
+    use sensus_core::shaders::teichopsia_glsl;
+    assert!(!teichopsia_glsl().is_empty());
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -73,7 +73,7 @@ fn filter(img: DynamicImage, /* filter-specific params */, strength: f32) -> Dyn
 
 | Module | Phase | Issues | Filters |
 |---|---|---|---|
-| `vision` | 1–5 | #2, #3, #4, #5, #6, #19, #29, #36, #37, #56, #57 | color vision deficiency, tetrachromacy, refraction, visual field defects, light / transparency, depth-aware blur, diplopia, nystagmus, starbursts, eye_strain, dry_eye, contrast_sensitivity, detail_loss |
+| `vision` | 1–5 | #2, #3, #4, #5, #6, #19, #29, #36, #37, #56, #57, #58 | color vision deficiency, tetrachromacy, refraction, visual field defects, light / transparency, depth-aware blur, diplopia, nystagmus, starbursts, eye_strain, dry_eye, contrast_sensitivity, detail_loss, teichopsia |
 | `hearing` | 4 | #7, #8, #9 | hearing loss, pitch shift, balance / vertigo |
 | `stereo` | 6 | #31, #32 | MPO stereo photography → depth map (`split_mpo`, `stereo_to_depth`); Android XMP Depth extraction (`read_xmp_depth`) |
 | `pipeline` | 4 | #10 | filter composition ✅ |
@@ -125,6 +125,17 @@ Formula: `output = 0.5 + (input − 0.5) × (1.0 − strength × 0.5)`
 
 - `strength = 0.0` → identity (same as source image)
 - `strength = 1.0` → 50% contrast compression (output luminance variance < input)
+
+## Teichopsia filter (#58)
+
+`teichopsia(img, strength)` simulates the fortification spectra (zigzag luminance
+arcs) seen as a migraine aura.
+
+- Ring region (normalized distance 0.2–0.5 from center): additive saw-wave brightness overlay
+- Inner scotoma (distance < 0.2): darkened by `strength × 0.7`
+- `strength = 0.0` → identity; `strength = 1.0` → full effect
+
+> **医学的注記**: 偏頭痛の前兆として 20〜30 分続く。初めて経験する場合は眼科・神経内科を受診。
 
 ## Auditory Processing Disorder (APD) (Issue #38)
 


### PR DESCRIPTION
closes #58

## 変更内容
- `teichopsia(img, strength)` を `vision.rs` に追加（要塞スペクトル / ジグザグ光輪 + scotoma）
- `Filter::Teichopsia` を `lib.rs` に追加
- `teichopsia.frag` GLSL シェーダ追加
- `docs/overview.md` に医学的注記追加
- テスト: strength=0 → PSNR ≥ 60 dB、strength=1 → 中心暗化

cargo test: 302 passed