### PR TITLE
feat: vision: Flickering Stars フィルタ追加 (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **vision: Flickering Stars フィルタ追加** (#59):
+  `flickering_stars(img, strength, seed)` を `vision.rs` に追加。
+  LCG でランダムな光点を生成して additive blend する。光点数 = `(strength × 200.0) as usize`。
+  各光点は半径 2 px の矩形ブロブ。`Filter::FlickeringStars` を `lib.rs` に追加。
+  `flickering_stars.frag` GLSL シェーダ追加。
+  `docs/overview.md` に医学的注記追加:「急激な光点の増加・カーテン状の視野欠損を伴う場合は網膜剥離の前兆。即受診。」
+  テスト: strength=0 → identity、strength=1 → 出力の最大輝度が入力より高いこと。
+
 - **vision: Teichopsia フィルタ追加** (#58):
   `teichopsia(img, strength)` を `vision.rs` に追加。視野周辺にジグザグ縞の光（要塞スペクトル）を重畳し、
   内側（scotoma）を暗化する。リング領域（正規化距離 0.2〜0.5）で saw wave 輝度加算、

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -70,6 +70,8 @@ pub enum Filter {
     DetailLoss,
     // vision (Phase N / #58: teichopsia)
     Teichopsia,
+    // vision (Phase N / #59: flickering stars)
+    FlickeringStars,
 }
 
 /// Apply a [`Filter`] to an image at a given strength (`0.0..=1.0`).
@@ -114,6 +116,7 @@ pub fn apply(
         Filter::ContrastSensitivity => vision::contrast_sensitivity(img, strength),
         Filter::DetailLoss => vision::detail_loss(img, strength),
         Filter::Teichopsia => vision::teichopsia(img, strength),
+        Filter::FlickeringStars => vision::flickering_stars(img, strength, 0),
     }
 }
 

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -85,6 +85,7 @@ impl FilterStep {
             Filter::Nystagmus => vision::nystagmus(img, self.strength, self.amplitude, self.direction_deg),
             Filter::Starbursts => vision::starbursts(img, self.strength, self.num_rays, self.ray_length_ratio, self.threshold),
             Filter::Metamorphopsia => vision::metamorphopsia(img, self.strength, self.meta_freq, self.meta_seed),
+            Filter::FlickeringStars => vision::flickering_stars(img, self.strength, self.seed),
             f => crate::apply(f, img, self.strength),
         }
     }

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -136,6 +136,16 @@ pub fn teichopsia_uniforms(strength: f32) -> SimpleStrengthUniforms {
     SimpleStrengthUniforms { strength }
 }
 
+/// flickering_stars.frag の GLSL ES 3.00 ソースを返す。
+pub fn flickering_stars_glsl() -> &'static str {
+    include_str!("shaders/flickering_stars.frag")
+}
+
+/// flickering_stars の uniform を返す。
+pub fn flickering_stars_uniforms(strength: f32) -> SimpleStrengthUniforms {
+    SimpleStrengthUniforms { strength }
+}
+
 /// photophobia.frag の GLSL ES 3.00 ソースを返す。
 pub fn photophobia_glsl() -> &'static str {
     include_str!("shaders/photophobia.frag")

--- a/crates/core/src/shaders/flickering_stars.frag
+++ b/crates/core/src/shaders/flickering_stars.frag
@@ -1,0 +1,48 @@
+#version 300 es
+precision mediump float;
+uniform sampler2D u_image;
+uniform float u_strength;
+uniform float u_seed;
+uniform vec2 u_resolution;
+in vec2 v_texcoord;
+out vec4 out_color;
+
+// simple hash: float -> float in [0,1]
+float hash(float n) {
+    return fract(sin(n) * 43758.5453123);
+}
+
+// sRGB -> linear
+float srgb_to_linear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+// linear -> sRGB
+float linear_to_srgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 c = texture(u_image, v_texcoord);
+    vec3 lin = vec3(srgb_to_linear(c.r), srgb_to_linear(c.g), srgb_to_linear(c.b));
+
+    float count = u_strength * 200.0;
+    float blob_radius = 2.0;
+    float brightness_add = 0.0;
+
+    vec2 px = v_texcoord * u_resolution;
+
+    for (float i = 0.0; i < 200.0; i++) {
+        if (i >= count) break;
+        float h = hash(i + u_seed * 1000.0);
+        float h2 = hash(i + u_seed * 1000.0 + 7654.321);
+        float h3 = hash(i + u_seed * 1000.0 + 9876.543);
+        vec2 star = vec2(h * u_resolution.x, h2 * u_resolution.y);
+        float dist = length(px - star);
+        if (dist <= blob_radius) {
+            brightness_add += 0.5 + h3 * 0.5;
+        }
+    }
+
+    vec3 result = clamp(lin + vec3(brightness_add), 0.0, 1.0);
+    out_color = vec4(linear_to_srgb(result.r), linear_to_srgb(result.g), linear_to_srgb(result.b), c.a);
+}

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2581,6 +2581,80 @@ pub fn teichopsia(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
     Ok(DynamicImage::ImageRgba8(rgba))
 }
 
+// ---------------------------------------------------------------
+// Issue #59: Flickering Stars フィルタ
+// ---------------------------------------------------------------
+
+/// 閃光光点（Flickering Stars）シミュレーション。
+///
+/// LCG でランダムな光点を生成して additive blend する。
+/// 各光点は半径 2 px の矩形ブロブ（簡易実装）。
+///
+/// > **医学的注記**: 急激な光点の増加・カーテン状の視野欠損を伴う場合は
+/// > 網膜剥離の前兆。即受診。
+///
+/// - `strength`: 0.0 = 光点ゼロ（identity）, 1.0 = 200 点
+/// - `seed`: LCG の初期シード（フレーム間の一貫性に使用）
+pub fn flickering_stars(img: DynamicImage, strength: f32, seed: u64) -> Result<DynamicImage> {
+    let s = normalize_strength(strength);
+    let rgba = img.to_rgba8();
+    let count = (s * 200.0) as usize;
+    if count == 0 {
+        return Ok(DynamicImage::ImageRgba8(rgba));
+    }
+
+    let width = rgba.width();
+    let height = rgba.height();
+    let w_f = width as f32;
+    let h_f = height as f32;
+
+    // LCG ヘルパー
+    let lcg_next = |state: u64| -> (u64, f32) {
+        let next = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let fval = (next >> 32) as f32 / u32::MAX as f32;
+        (next, fval)
+    };
+
+    let mut state = seed.wrapping_mul(0x9e3779b97f4a7c15).wrapping_add(1);
+
+    // linear sRGB に変換して作業
+    let (mut linear, alpha) = rgba_to_linear_planes(&rgba);
+
+    const BLOB_RADIUS: i32 = 2;
+
+    for _ in 0..count {
+        let (s1, fx) = lcg_next(state);
+        let (s2, fy) = lcg_next(s1);
+        // 輝度 0.5..1.0（白っぽい光点）
+        let (s3, fb) = lcg_next(s2);
+        state = s3;
+
+        let cx = (fx * w_f) as i32;
+        let cy = (fy * h_f) as i32;
+        let brightness = 0.5 + fb * 0.5;
+
+        for dy in -BLOB_RADIUS..=BLOB_RADIUS {
+            for dx in -BLOB_RADIUS..=BLOB_RADIUS {
+                let px = cx + dx;
+                let py = cy + dy;
+                if px < 0 || py < 0 || px >= width as i32 || py >= height as i32 {
+                    continue;
+                }
+                let idx = py as usize * width as usize + px as usize;
+                let p = &mut linear[idx];
+                p[0] = (p[0] + brightness).min(1.0);
+                p[1] = (p[1] + brightness).min(1.0);
+                p[2] = (p[2] + brightness).min(1.0);
+            }
+        }
+    }
+
+    let out = linear_planes_to_rgba(&linear, &alpha, width, height);
+    Ok(DynamicImage::ImageRgba8(out))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5263,6 +5337,34 @@ mod tests {
         let center = out.get_pixel(32, 32);
         let brightness = center[0] as u32 + center[1] as u32 + center[2] as u32;
         assert!(brightness < 600, "teichopsia strength=1 must darken center (got {brightness})");
+    }
+
+    // -------------------------------------------------------
+    // flickering_stars tests
+    // -------------------------------------------------------
+
+    #[test]
+    fn flickering_stars_strength_zero_identity() {
+        let mut img = RgbaImage::new(64, 64);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = Rgba([(x * 3 + y * 7) as u8, (y * 4) as u8, 100, 255]);
+        }
+        let orig = img.clone().into_raw();
+        let out = flickering_stars(DynamicImage::ImageRgba8(img), 0.0, 42).unwrap().to_rgba8().into_raw();
+        assert_eq!(orig, out, "flickering_stars strength=0 must be identity");
+    }
+
+    #[test]
+    fn flickering_stars_strength_one_increases_max_brightness() {
+        let mut img = RgbaImage::new(64, 64);
+        for px in img.pixels_mut() {
+            // 暗めの画像で始める（最大輝度が additive で上がることを確認）
+            *px = Rgba([50, 50, 50, 255]);
+        }
+        let orig_max: u8 = img.pixels().map(|p| p[0].max(p[1]).max(p[2])).max().unwrap_or(0);
+        let out = flickering_stars(DynamicImage::ImageRgba8(img), 1.0, 42).unwrap().to_rgba8();
+        let out_max: u8 = out.pixels().map(|p| p[0].max(p[1]).max(p[2])).max().unwrap_or(0);
+        assert!(out_max > orig_max, "flickering_stars strength=1 must increase max brightness (orig={orig_max}, out={out_max})");
     }
 }
 

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -975,3 +975,9 @@ fn shader_teichopsia_glsl_is_not_empty() {
     use sensus_core::shaders::teichopsia_glsl;
     assert!(!teichopsia_glsl().is_empty());
 }
+
+#[test]
+fn shader_flickering_stars_glsl_is_not_empty() {
+    use sensus_core::shaders::flickering_stars_glsl;
+    assert!(!flickering_stars_glsl().is_empty());
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -73,7 +73,7 @@ fn filter(img: DynamicImage, /* filter-specific params */, strength: f32) -> Dyn
 
 | Module | Phase | Issues | Filters |
 |---|---|---|---|
-| `vision` | 1–5 | #2, #3, #4, #5, #6, #19, #29, #36, #37, #56, #57, #58 | color vision deficiency, tetrachromacy, refraction, visual field defects, light / transparency, depth-aware blur, diplopia, nystagmus, starbursts, eye_strain, dry_eye, contrast_sensitivity, detail_loss, teichopsia |
+| `vision` | 1–5 | #2, #3, #4, #5, #6, #19, #29, #36, #37, #56, #57, #58, #59 | color vision deficiency, tetrachromacy, refraction, visual field defects, light / transparency, depth-aware blur, diplopia, nystagmus, starbursts, eye_strain, dry_eye, contrast_sensitivity, detail_loss, teichopsia, flickering_stars |
 | `hearing` | 4 | #7, #8, #9 | hearing loss, pitch shift, balance / vertigo |
 | `stereo` | 6 | #31, #32 | MPO stereo photography → depth map (`split_mpo`, `stereo_to_depth`); Android XMP Depth extraction (`read_xmp_depth`) |
 | `pipeline` | 4 | #10 | filter composition ✅ |
@@ -136,6 +136,17 @@ arcs) seen as a migraine aura.
 - `strength = 0.0` → identity; `strength = 1.0` → full effect
 
 > **医学的注記**: 偏頭痛の前兆として 20〜30 分続く。初めて経験する場合は眼科・神経内科を受診。
+
+## Flickering Stars filter (#59)
+
+`flickering_stars(img, strength, seed)` simulates photopsia (flashes of light)
+by additively blending random white blob points onto the image.
+
+- Point count = `(strength × 200.0) as usize` (200 points at strength=1.0)
+- Each point is a 2 px rectangular blob with additive luminance 0.5–1.0
+- `strength = 0.0` → identity (zero points); `strength = 1.0` → 200 white blobs
+
+> **医学的注記**: 急激な光点の増加・カーテン状の視野欠損を伴う場合は網膜剥離の前兆。即受診。
 
 ## Auditory Processing Disorder (APD) (Issue #38)
 


### PR DESCRIPTION
closes #59

## 変更内容
- `flickering_stars(img, strength, seed)` を `vision.rs` に追加（LCG 光点 additive blend）
- 光点数 = `(strength × 200.0) as usize`、各光点は半径 2 px ブロブ
- `Filter::FlickeringStars` を `lib.rs` に追加
- `pipeline.rs` に seed パラメータ対応を追加
- `flickering_stars.frag` GLSL シェーダ追加（hash 関数ベース）
- `docs/overview.md` に医学的注記追加
- テスト: strength=0 → identity、strength=1 → 最大輝度が入力より高いこと

cargo test: 305 passed