### PR TITLE
feat: starbursts に波長分散（虹色光芒）オプション追加 (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **vision: starbursts に波長分散（虹色光芒）オプション追加** (#67):
+  `starbursts()` シグネチャに `dispersion: f32` パラメータを追加。
+  `dispersion=0.0`（デフォルト）は既存の白い光芒と後方互換。
+  `dispersion=1.0` では各 ray の角度を色相に対応した HSL 虹色（S=1, L=0.5）で着色し additive blend する。
+  `pipeline.rs` の `FilterStep` に `dispersion` フィールドを追加（デフォルト: 0.0）。
+  `shaders.rs` の `StarburstsUniforms` に `dispersion` フィールドを追加し `starbursts_uniforms()` の引数を更新。
+  `starbursts.frag` に `uDispersion` uniform を追加し UV 角度ベースの虹色近似を実装。
+  テスト: `dispersion=0.0` → 既存テスト通過、`dispersion=1.0` → 非グレー（虹色）ピクセル生成確認。
+
 - **vision: Flickering Stars フィルタ追加** (#59):
   `flickering_stars(img, strength, seed)` を `vision.rs` に追加。
   LCG でランダムな光点を生成して additive blend する。光点数 = `(strength × 200.0) as usize`。

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -109,7 +109,7 @@ pub fn apply(
         Filter::VestibularNeuritis => vision::vestibular_neuritis(img, strength),
         Filter::Diplopia => vision::diplopia(img, strength, 0.02, 0.01, 0.7),
         Filter::Nystagmus => vision::nystagmus(img, strength, 0.03, 0.0),
-        Filter::Starbursts => vision::starbursts(img, strength, 6, 0.1, 0.8),
+        Filter::Starbursts => vision::starbursts(img, strength, 6, 0.1, 0.8, 0.0),
         Filter::EyeStrain => vision::eye_strain(img, strength),
         Filter::DryEye => vision::dry_eye(img, strength),
         Filter::Metamorphopsia => vision::metamorphopsia(img, strength, 4.0, 0),

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -40,6 +40,8 @@ pub struct FilterStep {
     pub ray_length_ratio: f32,
     /// starbursts 輝度閾値。デフォルト: 0.8
     pub threshold: f32,
+    /// starbursts 波長分散（虹色光芒）。デフォルト: 0.0（白）
+    pub dispersion: f32,
     /// metamorphopsia 空間周波数。デフォルト: 4.0
     pub meta_freq: f32,
     /// metamorphopsia LCG シード。デフォルト: 0
@@ -66,6 +68,7 @@ impl FilterStep {
             num_rays: 6,
             ray_length_ratio: 0.1,
             threshold: 0.8,
+            dispersion: 0.0,
             meta_freq: 4.0,
             meta_seed: 0,
         }
@@ -83,7 +86,7 @@ impl FilterStep {
             Filter::Hemianopia => vision::hemianopia(img, self.strength, self.side),
             Filter::Diplopia => vision::diplopia(img, self.strength, self.offset_x, self.offset_y, self.ghost_strength),
             Filter::Nystagmus => vision::nystagmus(img, self.strength, self.amplitude, self.direction_deg),
-            Filter::Starbursts => vision::starbursts(img, self.strength, self.num_rays, self.ray_length_ratio, self.threshold),
+            Filter::Starbursts => vision::starbursts(img, self.strength, self.num_rays, self.ray_length_ratio, self.threshold, self.dispersion),
             Filter::Metamorphopsia => vision::metamorphopsia(img, self.strength, self.meta_freq, self.meta_seed),
             Filter::FlickeringStars => vision::flickering_stars(img, self.strength, self.seed),
             f => crate::apply(f, img, self.strength),

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -356,6 +356,7 @@ pub struct NystagmusUniforms {
 pub struct StarburstsUniforms {
     pub strength: f32,
     pub threshold: f32,
+    pub dispersion: f32,
 }
 
 /// diplopia の uniform を計算する。
@@ -391,8 +392,8 @@ pub fn nystagmus_uniforms(
 }
 
 /// starbursts の uniform を計算する。
-pub fn starbursts_uniforms(strength: f32, threshold: f32) -> StarburstsUniforms {
-    StarburstsUniforms { strength, threshold }
+pub fn starbursts_uniforms(strength: f32, threshold: f32, dispersion: f32) -> StarburstsUniforms {
+    StarburstsUniforms { strength, threshold, dispersion }
 }
 
 /// 視野欠損（vignette 系）フィルタの uniform。

--- a/crates/core/src/shaders/starbursts.frag
+++ b/crates/core/src/shaders/starbursts.frag
@@ -4,11 +4,13 @@ precision mediump float;
 // スターバースト（輝度閾値マスク）シミュレーション。
 // GPU 上でのフルレイマーチングは重いため、輝度が threshold を超える画素を
 // 強調するシンプルなブライトニングを行う。
+// uDispersion=0.0 → 白い強調、uDispersion=1.0 → 虹色（色相=方向角）の強調。
 // フルレイマーチング版は CPU 実装（vision::starbursts）を参照。
 
 uniform sampler2D uTexture;
 uniform float uStrength;
 uniform float uThreshold;
+uniform float uDispersion;
 
 in vec2 vTexCoord;
 out vec4 fragColor;
@@ -18,6 +20,21 @@ float srgbToLinear(float c) {
 }
 float linearToSrgb(float c) {
     return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+// HSL(H, S=1, L=0.5) → linear sRGB の虹色変換（GPU 用）
+vec3 hslRainbow(float hueDeg) {
+    float h = mod(hueDeg, 360.0);
+    float sector = floor(h / 60.0);
+    float f = h / 60.0 - sector;
+    float r, g, b;
+    if (sector < 1.0)      { r = 1.0;     g = f;       b = 0.0; }
+    else if (sector < 2.0) { r = 1.0 - f; g = 1.0;     b = 0.0; }
+    else if (sector < 3.0) { r = 0.0;     g = 1.0;     b = f; }
+    else if (sector < 4.0) { r = 0.0;     g = 1.0 - f; b = 1.0; }
+    else if (sector < 5.0) { r = f;       g = 0.0;     b = 1.0; }
+    else                   { r = 1.0;     g = 0.0;     b = 1.0 - f; }
+    return vec3(srgbToLinear(r), srgbToLinear(g), srgbToLinear(b));
 }
 
 void main() {
@@ -32,10 +49,15 @@ void main() {
     if (luma > uThreshold) {
         float excess = (luma - uThreshold) / max(1.0 - uThreshold, 0.001);
         float boost = excess * uStrength;
+        // UV 座標を角度に変換して虹色レイを近似
+        float angle = degrees(atan(vTexCoord.y - 0.5, vTexCoord.x - 0.5));
+        vec3 rainbow = hslRainbow(angle);
+        vec3 white = vec3(1.0, 1.0, 1.0);
+        vec3 rayColor = mix(white, rainbow, uDispersion);
         fragColor = vec4(
-            linearToSrgb(clamp(rl + boost, 0.0, 1.0)),
-            linearToSrgb(clamp(gl + boost, 0.0, 1.0)),
-            linearToSrgb(clamp(bl + boost, 0.0, 1.0)),
+            linearToSrgb(clamp(rl + boost * rayColor.r, 0.0, 1.0)),
+            linearToSrgb(clamp(gl + boost * rayColor.g, 0.0, 1.0)),
+            linearToSrgb(clamp(bl + boost * rayColor.b, 0.0, 1.0)),
             orig.a
         );
     } else {

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2044,12 +2044,44 @@ pub fn nystagmus(
 /// - `num_rays`: 光芒の本数（4/6/8 推奨）
 /// - `ray_length_ratio`: 光芒の長さ（min(W,H) 比）
 /// - `threshold`: 光芒が発生する輝度閾値（0.0..=1.0）
+/// HSL (hue 0..360, s=1, l=0.5) → linear sRGB の変換（分散レイ色に使用）。
+///
+/// 純粋な彩度 1 の虹色を返す内部ヘルパー。
+#[inline]
+fn hsl_rainbow_to_linear(hue_deg: f32) -> [f32; 3] {
+    // H ∈ [0, 360), S = 1, L = 0.5 の特殊ケースを展開する。
+    // C = (1 - |2L - 1|) × S = 1, X = C × (1 - |H/60 mod 2 - 1|), m = L - C/2 = 0
+    let h = hue_deg.rem_euclid(360.0);
+    let sector = (h / 60.0) as u32;
+    let f = h / 60.0 - sector as f32;
+    let (r, g, b) = match sector {
+        0 => (1.0, f, 0.0),
+        1 => (1.0 - f, 1.0, 0.0),
+        2 => (0.0, 1.0, f),
+        3 => (0.0, 1.0 - f, 1.0),
+        4 => (f, 0.0, 1.0),
+        _ => (1.0, 0.0, 1.0 - f),
+    };
+    // sRGB → linear（HSL で L=0.5 なら既に sRGB と見なして gamma 解除する）
+    [srgb_to_linear(r), srgb_to_linear(g), srgb_to_linear(b)]
+}
+
+/// 光芒（Starbursts）シミュレーション。
+///
+/// LASIK / 白内障手術後や高度乱視でレンズ面の回折から生じる放射状の光芒を再現する。
+///
+/// - `strength`: 0.0 = 元画像, 1.0 = 強い光芒
+/// - `num_rays`: 光芒の本数（0 で無効化）
+/// - `ray_length_ratio`: 光芒長（min(W,H) 比, 0.0..=1.0）
+/// - `threshold`: 光芒を発生させる輝度閾値（0.0..=1.0, BT.709 luma）
+/// - `dispersion`: 波長分散による虹色光芒（0.0 = 白, 1.0 = 完全虹色）
 pub fn starbursts(
     img: DynamicImage,
     strength: f32,
     num_rays: u32,
     ray_length_ratio: f32,
     threshold: f32,
+    dispersion: f32,
 ) -> Result<DynamicImage> {
     let s = normalize_strength(strength);
     if s == 0.0 {
@@ -2063,6 +2095,7 @@ pub fn starbursts(
 
     let ray_length_px = (ray_length_ratio.clamp(0.0, 1.0) * min_dim) as u32;
     let threshold = threshold.clamp(0.0, 1.0);
+    let dispersion = dispersion.clamp(0.0, 1.0);
 
     // 光芒レイヤー（linear sRGB, f32）
     let mut ray_layer: Vec<[f32; 3]> = vec![[0.0; 3]; (width * height) as usize];
@@ -2091,6 +2124,14 @@ pub fn starbursts(
                 let cos_t = theta.cos();
                 let sin_t = theta.sin();
 
+                // 分散色: 各 ray の角度を色相に対応させる（虹色）
+                // dispersion=0 → 白 (1,1,1), dispersion=1 → HSL 虹色
+                let angle_deg = theta.to_degrees().rem_euclid(360.0);
+                let rainbow = hsl_rainbow_to_linear(angle_deg);
+                let ray_r = lerp(1.0, rainbow[0], dispersion);
+                let ray_g = lerp(1.0, rainbow[1], dispersion);
+                let ray_b = lerp(1.0, rainbow[2], dispersion);
+
                 for t in 1..=ray_length_px {
                     let sx = x as i32 + (t as f32 * cos_t).round() as i32;
                     let sy = y as i32 + (t as f32 * sin_t).round() as i32;
@@ -2099,9 +2140,9 @@ pub fn starbursts(
                     }
                     let weight = src_intensity * (1.0 - t as f32 / ray_length_px as f32) * s;
                     let idx = sy as usize * width as usize + sx as usize;
-                    ray_layer[idx][0] += weight;
-                    ray_layer[idx][1] += weight;
-                    ray_layer[idx][2] += weight;
+                    ray_layer[idx][0] += weight * ray_r;
+                    ray_layer[idx][1] += weight * ray_g;
+                    ray_layer[idx][2] += weight * ray_b;
                 }
             }
         }
@@ -4904,7 +4945,7 @@ mod tests {
         let nearby_y = size / 2;
         let orig_nearby = img.get_pixel(nearby_x, nearby_y)[0];
 
-        let out = starbursts(DynamicImage::ImageRgba8(img), 1.0, 8, 0.2, 0.5).unwrap();
+        let out = starbursts(DynamicImage::ImageRgba8(img), 1.0, 8, 0.2, 0.5, 0.0).unwrap();
         let out_nearby = out.to_rgba8().get_pixel(nearby_x, nearby_y)[0];
 
         assert!(
@@ -4919,7 +4960,7 @@ mod tests {
         let mut img = RgbaImage::from_pixel(size, size, Rgba([0, 0, 0, 255]));
         img.put_pixel(size / 2, size / 2, Rgba([255, 255, 255, 255]));
         let orig = img.clone().into_raw();
-        let out = starbursts(DynamicImage::ImageRgba8(img), 0.0, 6, 0.1, 0.5).unwrap();
+        let out = starbursts(DynamicImage::ImageRgba8(img), 0.0, 6, 0.1, 0.5, 0.0).unwrap();
         let out_raw = out.to_rgba8().into_raw();
         let max_err = orig.iter().zip(out_raw.iter())
             .map(|(&a, &b)| (a as i32 - b as i32).unsigned_abs())
@@ -4927,6 +4968,29 @@ mod tests {
             .unwrap_or(0);
         // strength=0 は early return するため byte-exact 一致するはず
         assert!(max_err == 0, "strength=0 should be byte-exact identity, max_err={max_err}");
+    }
+
+    #[test]
+    fn starbursts_dispersion_one_produces_rainbow() {
+        // 中央に白い輝点を置き、dispersion=1.0 で光芒を生成する。
+        // 虹色光芒なのでRGB チャネルが互いに異なる値を持つことを確認する。
+        let size = 64_u32;
+        let mut img = RgbaImage::from_pixel(size, size, Rgba([0, 0, 0, 255]));
+        img.put_pixel(size / 2, size / 2, Rgba([255, 255, 255, 255]));
+        let out = starbursts(
+            DynamicImage::ImageRgba8(img),
+            1.0, 8, 0.3, 0.5, 1.0,
+        ).unwrap().to_rgba8();
+
+        // 全ピクセルの R/G/B の最大値を収集し、チャネル間で差があることを確認
+        let mut any_diff = false;
+        for px in out.pixels() {
+            if px[0] != px[1] || px[1] != px[2] {
+                any_diff = true;
+                break;
+            }
+        }
+        assert!(any_diff, "dispersion=1.0 should produce colored (non-gray) pixels");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Issue #67 の実装。

### 変更内容
- `vision::starbursts()` に `dispersion: f32` パラメータを追加
- `dispersion=0.0`（デフォルト）は既存の白い光芒と後方互換
- `dispersion=1.0` で各 ray を角度対応の HSL 虹色で着色
- `pipeline.rs` `FilterStep` に `dispersion` フィールド追加（デフォルト: 0.0）
- `shaders.rs` `StarburstsUniforms` / `starbursts_uniforms()` を更新
- `starbursts.frag` に `uDispersion` uniform 追加
- テスト追加: `dispersion=1.0` → 非グレーピクセル生成確認

### Tests
`cargo test` 全件通過