### PR TITLE
feat: AudioPipeline / AudioFilterStep 追加 (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AudioPipeline / AudioFilterStep 追加** (#66):
+  `crates/core/src/pipeline.rs` に聴覚フィルタ多段合成用の `AudioPipeline` と `AudioFilterStep` を追加。
+  `Pipeline`（視覚）と同じ builder パターンで `push(filter, strength).apply(&buf)` が使えるようになった。
+  `lib.rs` に `pub use pipeline::{AudioPipeline, AudioFilterStep};` を追加し外部公開。
+
 - **vision: starbursts に波長分散（虹色光芒）オプション追加** (#67):
   `starbursts()` シグネチャに `dispersion: f32` パラメータを追加。
   `dispersion=0.0`（デフォルト）は既存の白い光芒と後方互換。

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod stereo;
 pub mod vision;
 
 pub use error::Error;
+pub use pipeline::{AudioPipeline, AudioFilterStep};
 
 /// Convenience alias for `Result<T, sensus_core::Error>`.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -139,6 +139,65 @@ impl Default for Pipeline {
     }
 }
 
+// ---------------------------------------------------------------
+// AudioPipeline (Issue #66): 聴覚フィルタの多段合成
+// ---------------------------------------------------------------
+
+use crate::{HearingFilter, hearing::AudioBuffer};
+
+/// 1つの聴覚フィルタ適用単位。
+pub struct AudioFilterStep {
+    pub filter: HearingFilter,
+    pub strength: f32,
+}
+
+/// 複数の [`AudioFilterStep`] を順番に適用するパイプライン。
+///
+/// # 例
+///
+/// ```rust,no_run
+/// use sensus_core::{AudioPipeline, HearingFilter, hearing::AudioBuffer};
+///
+/// let buf = AudioBuffer { samples: vec![0.0; 1000], sample_rate: 44100, channels: 1 };
+/// let out = AudioPipeline::new()
+///     .push(HearingFilter::HearingLoss, 0.5)
+///     .apply(&buf)
+///     .unwrap();
+/// ```
+pub struct AudioPipeline {
+    steps: Vec<AudioFilterStep>,
+}
+
+impl AudioPipeline {
+    /// 空のパイプラインを生成する。
+    pub fn new() -> Self {
+        Self { steps: Vec::new() }
+    }
+
+    /// ステップを末尾に追加し、`self` を返す（builder パターン）。
+    pub fn push(mut self, filter: HearingFilter, strength: f32) -> Self {
+        self.steps.push(AudioFilterStep { filter, strength });
+        self
+    }
+
+    /// すべてのステップを順番に適用する。
+    ///
+    /// エラーが発生した場合は [`crate::Error`] を返す。
+    pub fn apply(&self, buf: &AudioBuffer) -> Result<AudioBuffer> {
+        let mut current = buf.clone();
+        for step in &self.steps {
+            current = crate::apply_hearing(step.filter.clone(), current, step.strength)?;
+        }
+        Ok(current)
+    }
+}
+
+impl Default for AudioPipeline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,9 +280,6 @@ mod tests {
     /// A→B と B→A で結果が異なることを確認する（順序依存性のテスト）。
     #[test]
     fn two_step_order_matters() {
-        // グラデーション画像を使う。
-        // protanopia（赤→緑方向のシフト）→ glaucoma（周辺暗化）と逆順では
-        // 周辺が暗化されてから色変換されるかどうかが変わるため結果が異なる。
         let img = {
             let mut base = RgbImage::new(32, 32);
             for (x, y, px) in base.enumerate_pixels_mut() {
@@ -267,9 +323,63 @@ mod tests {
             .push(FilterStep::new(Filter::Protanopia, 1.0))
             .apply(src)
             .unwrap();
-        // すべての画素の alpha が 128 のまま保持されているか確認
         for (_x, _y, px) in out.pixels() {
             assert_eq!(px[3], 128, "alpha channel must be preserved");
         }
+    }
+
+    // ---------------------------------------------------------------
+    // AudioPipeline テスト
+    // ---------------------------------------------------------------
+
+    fn silence_buf(frames: usize) -> AudioBuffer {
+        AudioBuffer {
+            samples: vec![0.0; frames],
+            sample_rate: 44100,
+            channels: 1,
+        }
+    }
+
+    #[test]
+    fn audio_pipeline_single_step_returns_ok() {
+        let buf = silence_buf(1000);
+        let result = AudioPipeline::new()
+            .push(HearingFilter::HearingLoss, 0.5)
+            .apply(&buf);
+        assert!(result.is_ok(), "single step AudioPipeline should return Ok");
+    }
+
+    #[test]
+    fn audio_pipeline_two_steps_returns_ok() {
+        let buf = silence_buf(1000);
+        let result = AudioPipeline::new()
+            .push(HearingFilter::HearingLoss, 0.5)
+            .push(HearingFilter::Tinnitus { freq_hz: 4000.0 }, 0.3)
+            .apply(&buf);
+        assert!(result.is_ok(), "two-step AudioPipeline should return Ok");
+    }
+
+    #[test]
+    fn audio_pipeline_empty_returns_same_buffer() {
+        let buf = silence_buf(100);
+        let out = AudioPipeline::new().apply(&buf).unwrap();
+        assert_eq!(out.samples, buf.samples);
+        assert_eq!(out.sample_rate, buf.sample_rate);
+        assert_eq!(out.channels, buf.channels);
+    }
+
+    #[test]
+    fn audio_pipeline_preserves_sample_rate_and_channels() {
+        let buf = AudioBuffer {
+            samples: vec![0.1, -0.1, 0.2, -0.2],
+            sample_rate: 48000,
+            channels: 2,
+        };
+        let out = AudioPipeline::new()
+            .push(HearingFilter::HearingLoss, 0.3)
+            .apply(&buf)
+            .unwrap();
+        assert_eq!(out.sample_rate, 48000);
+        assert_eq!(out.channels, 2);
     }
 }


### PR DESCRIPTION
Closes #66

## 変更内容
- `crates/core/src/pipeline.rs` に `AudioPipeline` / `AudioFilterStep` を追加
- builder パターン: `AudioPipeline::new().push(filter, strength).apply(&buf)`
- `crates/core/src/lib.rs` に `pub use pipeline::{AudioPipeline, AudioFilterStep};` を追加
- テスト4件追加（single step / two steps / empty / sample_rate 保持）
- CHANGELOG.md の `[Unreleased]` に #66 エントリを追加