### PR TITLE
fix: review 指摘全件修正 round2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **fix: レビュー指摘全件修正（M×3/S×5/N×2）**:
-  - [M-1] 新GLSL 4本の uniform 命名規則を camelCase に統一（`u_texture` → `uTexture`, `v_texcoord` → `vTexCoord` 等）
-  - [M-2] `detail_loss.frag` を GLSL 9点平均サンプルに変更して CPU 実装（タイル内全画素平均）に近似させる
-  - [M-3] `flickering_stars.frag` の `u_seed` を `float` → `uint uSeed` に変更（浮動小数精度劣化防止）
-  - [S-1] `vision.rs` の `manual_range_contains` clippy 警告を `(0.2..=0.5).contains(&dist)` に修正
-  - [S-2] `vision.rs` の `doc_lazy_continuation` clippy 警告を修正（継続行に `///` を補う）
-  - [S-3] `teichopsia.frag` に `uAspect` を追加して aspect 補正による楕円化防止
-  - [S-4] `docs/overview.md` の glaucoma 項目に弧状暗点モードの左右眼実装基準を明記
-  - [S-5] `detail_loss_with_cell_size` の docコメントに `cell_size=1` 挙動を説明
-  - [N-1] `shader_equivalence.rs` に新4フィルタのテスト追加（contrast_sensitivity PSNR ≥ 30 dB / detail_loss CPU-GPU 等価性 / teichopsia コンパイルテスト + strength=0 identity）
-  - [N-2] `pipeline.rs` の `FilterStep` に設計メモコメントを追加
-  - bench エラー（`Filter::Astigmatism/Starbursts/Floaters` が struct variant）を修正
-  - `shader_equivalence.rs` の `FRAC_1_SQRT_2` 精度警告、`stereo.rs` の `format!` 警告、`vision.rs` の `absurd_extreme_comparisons` エラーを修正
+- **fix: review 指摘全件修正 round2（S×4/N×3）**:
+  - [S-1] `sim_vignette_fov` に `aspect: f32` 引数を追加してシェーダ（`uAspect`）と一致させる。非正方形（64×32）テスト `shader_equiv_glaucoma_non_square_64x32_psnr` を追加（PSNR ≥ 30 dB）
+  - [S-2] `floaters.frag` の `uniform float uSeed` → `uniform uint uSeed` に変更（24bit 精度劣化防止）。`FloatersUniforms.seed: f32 → u32`、`floaters_uniforms` を `seed as u32` に修正
+  - [S-3] `nyctalopia.frag` の命名を確認 — `uTexture`, `uStrength`, `vTexCoord`, `fragColor`, `srgbToLinear`, `linearToSrgb` が他シェーダと一致しており修正不要
+  - [S-4] `cataract.frag` の `uniform float uSeed` → `uniform uint uSeed` に変更（同 S-2 と同じ精度劣化防止）
+  - [N-1] `bppv_rotation.frag` の `clamp` 処理にコメント「範囲外の UV は端ピクセルにクランプする（CPU 実装と同じ動作）」を追記
+  - [N-2] `shader_equivalence.rs` に `shader_photophobia_glsl_is_not_empty` テストを追加
+  - [N-3] `starbursts.frag` の `sector < 1.0` 分岐付近にコメント「H=360° は H=0°（赤）と同値になる（HSL の周期性）」を追記
 
-- **AudioPipeline / AudioFilterStep 追加** (#66):
+- **fix: レビュー指摘全件修正（M×3/S×5/N×2）**:
   `crates/core/src/pipeline.rs` に聴覚フィルタ多段合成用の `AudioPipeline` と `AudioFilterStep` を追加。
   `Pipeline`（視覚）と同じ builder パターンで `push(filter, strength).apply(&buf)` が使えるようになった。
   `lib.rs` に `pub use pipeline::{AudioPipeline, AudioFilterStep};` を追加し外部公開。

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -544,7 +544,7 @@ pub struct BppvRotationUniforms {
 #[derive(Debug, Clone)]
 pub struct FloatersUniforms {
     pub strength: f32,
-    pub seed: f32,
+    pub seed: u32,
 }
 
 /// tetrachromacy の uniform を計算する。
@@ -578,7 +578,7 @@ pub fn bppv_rotation_uniforms(strength: f32, time: f32) -> BppvRotationUniforms 
 pub fn floaters_uniforms(strength: f32, seed: u64) -> FloatersUniforms {
     FloatersUniforms {
         strength,
-        seed: seed as f32,
+        seed: seed as u32,
     }
 }
 

--- a/crates/core/src/shaders/bppv_rotation.frag
+++ b/crates/core/src/shaders/bppv_rotation.frag
@@ -40,4 +40,5 @@ void main() {
     ) + center;
 
     fragColor = texture(uTexture, clamp(srcUV, 0.0, 1.0));
+    // 範囲外の UV は端ピクセルにクランプする（CPU 実装と同じ動作）
 }

--- a/crates/core/src/shaders/cataract.frag
+++ b/crates/core/src/shaders/cataract.frag
@@ -20,7 +20,7 @@ precision mediump float;
 
 uniform sampler2D uTexture;
 uniform float uStrength;
-uniform float uSeed;
+uniform uint uSeed;    // u64 シードの下位 32bit を uint として渡す（float 経由の精度損失を回避）
 uniform vec2 uResolution;
 
 in vec2 vTexCoord;

--- a/crates/core/src/shaders/floaters.frag
+++ b/crates/core/src/shaders/floaters.frag
@@ -11,7 +11,7 @@ precision mediump float;
 
 uniform sampler2D uTexture;
 uniform float uStrength;
-uniform float uSeed;   // u64 シードを f32 に変換した値
+uniform uint uSeed;    // u64 シードの下位 32bit を uint として渡す（float 経由の精度損失を回避）
 
 in vec2 vTexCoord;
 out vec4 fragColor;
@@ -27,8 +27,9 @@ void main() {
     vec4 orig = texture(uTexture, vTexCoord);
 
     // ブロック単位でハッシュを計算（8x8 相当の粗さ）
-    vec2 blockUV = floor(vTexCoord * 16.0 + uSeed * 0.01) / 16.0;
-    float noise = hash21(blockUV + uSeed * 0.001);
+    float seedF = float(uSeed);
+    vec2 blockUV = floor(vTexCoord * 16.0 + seedF * 0.01) / 16.0;
+    float noise = hash21(blockUV + seedF * 0.001);
 
     // noise が閾値を下回る領域を floater として暗化
     float floaterMask = 1.0;

--- a/crates/core/src/shaders/starbursts.frag
+++ b/crates/core/src/shaders/starbursts.frag
@@ -28,6 +28,7 @@ vec3 hslRainbow(float hueDeg) {
     float sector = floor(h / 60.0);
     float f = h / 60.0 - sector;
     float r, g, b;
+    // H=360° は H=0°（赤）と同値になる（HSL の周期性）
     if (sector < 1.0)      { r = 1.0;     g = f;       b = 0.0; }
     else if (sector < 2.0) { r = 1.0 - f; g = 1.0;     b = 0.0; }
     else if (sector < 3.0) { r = 0.0;     g = 1.0;     b = f; }

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -586,17 +586,21 @@ fn shader_equiv_strength_zero_no_change() {
 
 /// glaucoma.frag / tunnel_vision.frag の計算を Rust で再現する。
 /// `inner_r`, `outer_r` を外から渡すことで両方に使用する。
-fn sim_vignette_fov(img: &RgbaImage, strength: f32, inner_r: f32, outer_r: f32) -> RgbaImage {
+/// `aspect` = width / height（シェーダの uAspect と同じ）。
+fn sim_vignette_fov(img: &RgbaImage, strength: f32, inner_r: f32, outer_r: f32, aspect: f32) -> RgbaImage {
     let (w, h) = img.dimensions();
-    // UV 空間でのコーナー距離: sqrt(0.5^2+0.5^2) = 1/sqrt(2)
-    let corner_dist = std::f32::consts::FRAC_1_SQRT_2;
+    // シェーダと同じ aspect 補正済みコーナー距離: sqrt((0.5*aspect)^2 + 0.5^2)
+    let corner_dist = (0.5 * aspect * 0.5 * aspect + 0.5 * 0.5_f32).sqrt();
     let mut out = img.clone();
     for y in 0..h {
         for x in 0..w {
             // UV 座標 (pixel center)
             let uv_x = (x as f32 + 0.5) / w as f32 - 0.5;
             let uv_y = (y as f32 + 0.5) / h as f32 - 0.5;
-            let d = (uv_x * uv_x + uv_y * uv_y).sqrt() / corner_dist;
+            // aspect 補正してから距離計算（シェーダと同じ）
+            let dx = uv_x * aspect;
+            let dy = uv_y;
+            let d = dx.hypot(dy) / corner_dist;
 
             let t = ((d - inner_r) / (outer_r - inner_r)).clamp(0.0, 1.0);
             let fade = t * t * (3.0 - 2.0 * t);
@@ -709,7 +713,7 @@ fn shader_equiv_glaucoma_strength_1_0_psnr() {
     let inner_r = 1.0 - u.strength * 0.7;
     let outer_r = (inner_r + 0.2_f32).min(1.0);
     let cpu_out = glaucoma(img.clone(), 1.0, GlaucomaMode::Vignette).unwrap().to_rgba8();
-    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r);
+    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r, 1.0);
     let db = psnr(&cpu_out, &gpu_sim);
     assert!(db >= 30.0, "glaucoma strength=1.0: PSNR {db:.1} dB < 30 dB");
 }
@@ -721,7 +725,7 @@ fn shader_equiv_glaucoma_strength_0_5_psnr() {
     let inner_r = 1.0 - u.strength * 0.7;
     let outer_r = (inner_r + 0.2_f32).min(1.0);
     let cpu_out = glaucoma(img.clone(), 0.5, GlaucomaMode::Vignette).unwrap().to_rgba8();
-    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r);
+    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r, 1.0);
     let db = psnr(&cpu_out, &gpu_sim);
     assert!(db >= 30.0, "glaucoma strength=0.5: PSNR {db:.1} dB < 30 dB");
 }
@@ -774,7 +778,7 @@ fn shader_equiv_tunnel_vision_strength_1_0_psnr() {
     let inner_r = (1.0 - u.strength) * 0.5;
     let outer_r = (inner_r + 0.05_f32).min(1.0);
     let cpu_out = tunnel_vision(img.clone(), 1.0).unwrap().to_rgba8();
-    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r);
+    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r, 1.0);
     let db = psnr(&cpu_out, &gpu_sim);
     assert!(db >= 30.0, "tunnel_vision strength=1.0: PSNR {db:.1} dB < 30 dB");
 }
@@ -786,7 +790,7 @@ fn shader_equiv_tunnel_vision_strength_0_5_psnr() {
     let inner_r = (1.0 - u.strength) * 0.5;
     let outer_r = (inner_r + 0.05_f32).min(1.0);
     let cpu_out = tunnel_vision(img.clone(), 0.5).unwrap().to_rgba8();
-    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r);
+    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r, 1.0);
     let db = psnr(&cpu_out, &gpu_sim);
     assert!(db >= 30.0, "tunnel_vision strength=0.5: PSNR {db:.1} dB < 30 dB");
 }
@@ -1116,4 +1120,45 @@ fn shader_teichopsia_glsl_compiles() {
 fn shader_flickering_stars_glsl_compiles_and_not_empty() {
     use sensus_core::shaders::flickering_stars_glsl;
     assert!(!flickering_stars_glsl().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// [S-1] 非正方形（64×32）の vignette_fov テスト
+// aspect 補正が正しく機能すれば CPU と GPU シミュレータの PSNR ≥ 30 dB
+// ---------------------------------------------------------------------------
+
+/// 64×32 の非正方形グラデーション画像を生成する。
+fn gradient_64x32() -> DynamicImage {
+    let mut img = RgbaImage::new(64, 32);
+    for y in 0..32u32 {
+        for x in 0..64u32 {
+            let v = (x * 4) as u8;
+            img.put_pixel(x, y, image::Rgba([v, v / 2, 255 - v, 255]));
+        }
+    }
+    DynamicImage::ImageRgba8(img)
+}
+
+#[test]
+fn shader_equiv_glaucoma_non_square_64x32_psnr() {
+    // 非正方形（width=64, height=32, aspect=2.0）で aspect 補正が機能することを確認
+    let img = gradient_64x32();
+    let u = glaucoma_uniforms(1.0, 64, 32);
+    let inner_r = 1.0 - u.strength * 0.7;
+    let outer_r = (inner_r + 0.2_f32).min(1.0);
+    let cpu_out = glaucoma(img.clone(), 1.0, GlaucomaMode::Vignette).unwrap().to_rgba8();
+    let aspect = 64.0_f32 / 32.0_f32; // 2.0
+    let gpu_sim = sim_vignette_fov(&img.to_rgba8(), u.strength, inner_r, outer_r, aspect);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 30.0, "glaucoma non-square 64×32: PSNR {db:.1} dB < 30 dB");
+}
+
+// ---------------------------------------------------------------------------
+// [N-2] photophobia コンパイルテスト
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shader_photophobia_glsl_is_not_empty() {
+    use sensus_core::shaders::photophobia_glsl;
+    assert!(!photophobia_glsl().is_empty());
 }


### PR DESCRIPTION
## 概要

should×4 / nit×3 全件修正。

## 修正内容

### [S-1] sim_vignette_fov に aspect 補正＋非正方形テスト追加
- `sim_vignette_fov` に `aspect: f32` 引数を追加し、シェーダ（`uAspect`）と一致させる
- 距離計算を `dx = uv_x * aspect` ベースに変更
- 非正方形（64×32）テスト `shader_equiv_glaucoma_non_square_64x32_psnr` を追加（PSNR ≥ 30 dB）

### [S-2] floaters.frag の uSeed を float → uint に変更
- `uniform float uSeed` → `uniform uint uSeed`（24bit 精度劣化防止）
- `FloatersUniforms.seed: f32 → u32`、`floaters_uniforms` を `seed as u32` に修正

### [S-3] nyctalopia.frag の命名確認
- `uTexture`, `uStrength`, `vTexCoord`, `fragColor`, `srgbToLinear`, `linearToSrgb` が他シェーダと一致しており修正不要

### [S-4] cataract.frag の uSeed を uint に変更
- `uniform float uSeed` → `uniform uint uSeed`（floaters.frag と同じ問題）

### [N-1] bppv_rotation.frag の clamp にコメント追加
- 「範囲外の UV は端ピクセルにクランプする（CPU 実装と同じ動作）」を追記

### [N-2] photophobia コンパイルテスト追加
- `shader_photophobia_glsl_is_not_empty` テストを追加

### [N-3] starbursts.frag の H=360° コメント追加
- 「H=360° は H=0°（赤）と同値になる（HSL の周期性）」を追記

## テスト結果

`cargo test`: **43 passed**, 0 failed
`cargo clippy --all-targets`: **警告 0 件**