### PR TITLE
fix: #96 detail_loss の apply 経路を GLSL/中心点方式に統一し等価テストを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix: kako-jun/sensus#96 `detail_loss` の apply 経路を等価テスト対象に統一**:
+  - `apply(Filter::DetailLoss)` / `pipeline` が呼ぶ `detail_loss_with_cell_size` を、タイル内全ピクセル linear sRGB 平均からタイル中心点サンプリング（pixelation）に変更。これで GLSL シェーダ（`detail_loss.frag`、universal-experience の表示経路 = 正本）・等価テスト済みの `detail_loss`・公開 API（apply 経由）の3者が同一アルゴリズムになった。`detail_loss_with_cell_size` と `detail_loss` の違いはタイルサイズの決め方（`cell_size` 直接指定 vs `strength` 導出）だけ
+  - apply 経路の関数（`detail_loss_with_cell_size`）に対する CPU↔GLSL 等価テストを追加: `shader_equiv_apply_detail_loss_cpu_gpu_psnr`（cell_size=7、半端境界、PSNR ≥ 60 dB）、`shader_equiv_apply_detail_loss_cell_size_20_psnr`（cell_size=20、PSNR ≥ 60 dB）。中心点サンプリング用シミュレータ `sim_detail_loss_shader_cell` も追加
+  - `detail_loss.frag` / `detail_loss` / `detail_loss_with_cell_size` の docコメントを統一後の事実に更新
+
 ## [0.4.0] - 2026-05-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "sensus"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "image",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "sensus-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "image",

--- a/crates/core/src/shaders/detail_loss.frag
+++ b/crates/core/src/shaders/detail_loss.frag
@@ -2,9 +2,9 @@
 // 細部消失（Detail Loss）シミュレーション。
 // 各ピクセルを所属タイルの中心点の色で置き換えることで、
 // のっぺりとした塊に見える視覚的効果を実現する（pixelation）。
-// CPU 実装（vision::detail_loss）と同一アルゴリズムを使用。
-// apply(Filter::DetailLoss) は vision::detail_loss_with_cell_size（全平均）を呼ぶため
-// このシェーダとはアルゴリズムが異なる点に注意（docs を参照）。
+// CPU 実装（vision::detail_loss / vision::detail_loss_with_cell_size）と同一アルゴリズム。
+// kako-jun/sensus#96: 以前は detail_loss_with_cell_size が全平均でこのシェーダと異なっていたが、
+// 中心点サンプリングに統一済み。apply(Filter::DetailLoss) 経路もこのシェーダと等価。
 precision mediump float;
 uniform sampler2D uTexture;
 uniform float uStrength;

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2505,8 +2505,9 @@ pub fn contrast_sensitivity(img: DynamicImage, strength: f32) -> Result<DynamicI
 ///
 /// ## アルゴリズムの注意
 /// このバリアントは**タイル中心点参照**（GLSL シェーダと同一アルゴリズム）。
-/// `apply(Filter::DetailLoss)` 経由時は `detail_loss_with_cell_size` を呼ぶため
-/// アルゴリズムが異なる（→ [`detail_loss_with_cell_size`] 参照）。
+/// `apply(Filter::DetailLoss)` 経由時は `detail_loss_with_cell_size` を呼ぶが、
+/// kako-jun/sensus#96 で同関数も中心点サンプリングに統一済みなので
+/// アルゴリズムは同一（異なるのはタイルサイズの決め方だけ → [`detail_loss_with_cell_size`] 参照）。
 pub fn detail_loss(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
     let s = normalize_strength(strength);
     let rgba = img.to_rgba8();
@@ -2562,10 +2563,14 @@ pub fn detail_loss(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
 /// `cell_size` が 1 の場合は各ピクセルが単独のセルになるため identity と等価です（早期リターン）。
 ///
 /// ## アルゴリズムの注意
-/// このバリアントは**タイル内全ピクセルの linear sRGB 平均**を使用する。
-/// これは [`detail_loss`]（タイル中心点参照）や GLSL シェーダと異なり、
-/// 視覚的に高品質だが CPU コストが増加する。
-/// `apply(Filter::DetailLoss)` 経由時はこのバリアントが呼ばれる。
+/// このバリアントは**タイル中心点参照**（pixelation）を使用する。
+/// これは [`detail_loss`] および GLSL シェーダ（`detail_loss.frag`）と同一アルゴリズムであり、
+/// 異なるのはタイルサイズの決め方だけ（こちらは `cell_size` 直接指定、[`detail_loss`] は
+/// `strength` から導出）。`apply(Filter::DetailLoss)` 経由時はこのバリアントが呼ばれる。
+///
+/// kako-jun/sensus#96: 以前はタイル内全ピクセルの linear sRGB 平均を使用しており、
+/// 公開 API（apply 経由）が GLSL シェーダとも等価テスト済み関数とも異なる出力を出していた。
+/// シェーダ（universal-experience の表示経路 = 正本）の中心点サンプリングに統一した。
 #[allow(unused_variables)]
 pub fn detail_loss_with_cell_size(img: DynamicImage, _strength: f32, cell_size: u32) -> Result<DynamicImage> {
     let rgba = img.to_rgba8();
@@ -2586,23 +2591,17 @@ pub fn detail_loss_with_cell_size(img: DynamicImage, _strength: f32, cell_size: 
             let y0 = ty * tile_size;
             let x1 = (x0 + tile_size).min(width);
             let y1 = (y0 + tile_size).min(height);
-            let count = ((x1 - x0) * (y1 - y0)) as u64;
-            if count == 0 {
+            if x1 <= x0 || y1 <= y0 {
                 continue;
             }
 
-            let mut sum = [0.0_f64; 3];
-            for py in y0..y1 {
-                for px in x0..x1 {
-                    let p = rgba.get_pixel(px, py);
-                    sum[0] += srgb_to_linear(p[0] as f32 / 255.0) as f64;
-                    sum[1] += srgb_to_linear(p[1] as f32 / 255.0) as f64;
-                    sum[2] += srgb_to_linear(p[2] as f32 / 255.0) as f64;
-                }
-            }
-            let avg_r = pack_u8(linear_to_srgb((sum[0] / count as f64) as f32));
-            let avg_g = pack_u8(linear_to_srgb((sum[1] / count as f64) as f32));
-            let avg_b = pack_u8(linear_to_srgb((sum[2] / count as f64) as f32));
+            // タイル中心1点をサンプリング（GLSL シェーダと同一アルゴリズム: pixelation）
+            let cx = (x0 + tile_size / 2).min(width - 1);
+            let cy = (y0 + tile_size / 2).min(height - 1);
+            let cp = rgba.get_pixel(cx, cy);
+            let avg_r = cp[0];
+            let avg_g = cp[1];
+            let avg_b = cp[2];
 
             for py in y0..y1 {
                 for px in x0..x1 {
@@ -2610,6 +2609,7 @@ pub fn detail_loss_with_cell_size(img: DynamicImage, _strength: f32, cell_size: 
                     p[0] = avg_r;
                     p[1] = avg_g;
                     p[2] = avg_b;
+                    // alpha はそのまま
                 }
             }
         }

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2497,7 +2497,7 @@ pub fn contrast_sensitivity(img: DynamicImage, strength: f32) -> Result<DynamicI
 
 /// 細部喪失（Detail Loss）シミュレーション。
 ///
-/// 矩形タイルごとに平均色に置き換える（pixelation）。
+/// 矩形タイルごとにタイル中心点の色に置き換える（pixelation）。
 /// タイルサイズ = `(strength * 20.0).max(1.0) as u32` px。
 ///
 /// - `strength = 0.0`: identity（タイルサイズ 1px = 変化なし）

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -1329,6 +1329,60 @@ fn shader_equiv_cataract_strength_zero_psnr() {
 // S-2: apply(Filter::DetailLoss) 経由のテスト
 // ---------------------------------------------------------------------------
 
+/// detail_loss シェーダ（detail_loss.frag, 中心点サンプリング）を、タイルサイズ = cell_size
+/// 直接指定で Rust シミュレートする。apply(Filter::DetailLoss) 経路（detail_loss_with_cell_size）
+/// の等価検証用（kako-jun/sensus#96）。
+fn sim_detail_loss_shader_cell(img: &RgbaImage, cell_size: u32) -> RgbaImage {
+    let (w, h) = img.dimensions();
+    let tile_size = cell_size.max(1) as f32;
+    let mut out = img.clone();
+    for y in 0..h {
+        for x in 0..w {
+            let tile_ox = (x as f32 / tile_size).floor() * tile_size;
+            let tile_oy = (y as f32 / tile_size).floor() * tile_size;
+            let center_px = (tile_ox + tile_size * 0.5, tile_oy + tile_size * 0.5);
+            let sx = (center_px.0.clamp(0.0, (w - 1) as f32)) as u32;
+            let sy = (center_px.1.clamp(0.0, (h - 1) as f32)) as u32;
+            let s = img.get_pixel(sx, sy);
+            let lin_r = srgb_to_linear(s[0] as f32 / 255.0);
+            let lin_g = srgb_to_linear(s[1] as f32 / 255.0);
+            let lin_b = srgb_to_linear(s[2] as f32 / 255.0);
+            let orig_alpha = img.get_pixel(x, y)[3];
+            out.put_pixel(x, y, image::Rgba([
+                (linear_to_srgb(lin_r.clamp(0.0, 1.0)) * 255.0).round() as u8,
+                (linear_to_srgb(lin_g.clamp(0.0, 1.0)) * 255.0).round() as u8,
+                (linear_to_srgb(lin_b.clamp(0.0, 1.0)) * 255.0).round() as u8,
+                orig_alpha,
+            ]));
+        }
+    }
+    out
+}
+
+/// kako-jun/sensus#96: apply(Filter::DetailLoss) が実際に呼ぶ detail_loss_with_cell_size を
+/// GLSL シェーダ（中心点サンプリング）と等価検証する。以前は同関数が全平均で、公開 API 経路が
+/// シェーダとも検証済み関数とも異なる出力を出していた。
+#[test]
+fn shader_equiv_apply_detail_loss_cpu_gpu_psnr() {
+    use sensus_core::vision::detail_loss_with_cell_size;
+    let img = color_chart_32();
+    // tile_size に半端な境界を含むよう cell_size=7 を使う（32 / 7 でタイルがはみ出す）
+    let cpu_out = detail_loss_with_cell_size(img.clone(), 1.0, 7).unwrap().to_rgba8();
+    let gpu_sim = sim_detail_loss_shader_cell(&img.to_rgba8(), 7);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 60.0, "apply(DetailLoss) cell_size=7 CPU/GPU: PSNR {db:.1} dB < 60 dB");
+}
+
+#[test]
+fn shader_equiv_apply_detail_loss_cell_size_20_psnr() {
+    use sensus_core::vision::detail_loss_with_cell_size;
+    let img = color_chart_32();
+    let cpu_out = detail_loss_with_cell_size(img.clone(), 1.0, 20).unwrap().to_rgba8();
+    let gpu_sim = sim_detail_loss_shader_cell(&img.to_rgba8(), 20);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 60.0, "apply(DetailLoss) cell_size=20 CPU/GPU: PSNR {db:.1} dB < 60 dB");
+}
+
 #[test]
 fn apply_detail_loss_strength_0_identity() {
     use sensus_core::{apply, Filter};

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -1404,6 +1404,119 @@ fn apply_detail_loss_strength_1_runs_without_crash() {
 }
 
 // ---------------------------------------------------------------------------
+// S-2b: apply(Filter::DetailLoss) 経路の非正方形・cell_size 境界・alpha 保存
+// （kako-jun/sensus#96 追加観点）
+// ---------------------------------------------------------------------------
+
+/// 32×64 の縦長グラデーション画像（gradient_64x32 の transpose 相当）。
+fn gradient_32x64() -> DynamicImage {
+    let mut img = RgbaImage::new(32, 64);
+    for y in 0..64u32 {
+        for x in 0..32u32 {
+            let v = (y * 4) as u8;
+            img.put_pixel(x, y, image::Rgba([v, v / 2, 255 - v, 255]));
+        }
+    }
+    DynamicImage::ImageRgba8(img)
+}
+
+/// alpha が画素ごとに変化する 32×32 RGBA 画像（alpha 保存検証用）。
+fn varying_alpha_32() -> DynamicImage {
+    let mut img = RgbaImage::new(32, 32);
+    for y in 0..32u32 {
+        for x in 0..32u32 {
+            let v = (x * 8) as u8;
+            let a = (y * 8) as u8;
+            img.put_pixel(x, y, image::Rgba([v, 255 - v, v / 2, a]));
+        }
+    }
+    DynamicImage::ImageRgba8(img)
+}
+
+/// kako-jun/sensus#96: 横長（64×32）でも apply 経路（detail_loss_with_cell_size）が
+/// 中心点サンプリングシェーダと等価。width が tile_size で割り切れない端タイルを含む。
+#[test]
+fn shader_equiv_apply_detail_loss_non_square_64x32_psnr() {
+    use sensus_core::vision::detail_loss_with_cell_size;
+    let img = gradient_64x32();
+    let cpu_out = detail_loss_with_cell_size(img.clone(), 1.0, 7).unwrap().to_rgba8();
+    let gpu_sim = sim_detail_loss_shader_cell(&img.to_rgba8(), 7);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 60.0, "apply(DetailLoss) non-square 64×32 cell_size=7: PSNR {db:.1} dB < 60 dB");
+}
+
+/// kako-jun/sensus#96: 縦長（32×64）でも apply 経路が中心点サンプリングシェーダと等価。
+/// 横長と縦長の両方を守ることで width/height の取り違えを検出する。
+#[test]
+fn shader_equiv_apply_detail_loss_non_square_32x64_psnr() {
+    use sensus_core::vision::detail_loss_with_cell_size;
+    let img = gradient_32x64();
+    let cpu_out = detail_loss_with_cell_size(img.clone(), 1.0, 7).unwrap().to_rgba8();
+    let gpu_sim = sim_detail_loss_shader_cell(&img.to_rgba8(), 7);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 60.0, "apply(DetailLoss) non-square 32×64 cell_size=7: PSNR {db:.1} dB < 60 dB");
+}
+
+/// kako-jun/sensus#96: cell_size=0 は tile_size = cell_size.max(1) = 1 で identity 早期リターン。
+/// strength を 1.0 にしても cell_size が支配的で何も変化しない契約を守る。
+#[test]
+fn apply_detail_loss_cell_size_0_identity() {
+    use sensus_core::vision::detail_loss_with_cell_size;
+    let img = color_chart_32();
+    let out = detail_loss_with_cell_size(img.clone(), 1.0, 0).unwrap().to_rgba8();
+    let orig = img.to_rgba8();
+    assert_eq!(out.as_raw(), orig.as_raw(), "detail_loss cell_size=0 should be identity (tile_size=max(1))");
+}
+
+/// kako-jun/sensus#96: cell_size が画像サイズを超えると全体が1タイルになり、
+/// 全画素が中心点（floor の (16,16)）の色になる。シミュレータと等価。
+#[test]
+fn shader_equiv_apply_detail_loss_cell_size_exceeds_image_psnr() {
+    use sensus_core::vision::detail_loss_with_cell_size;
+    let img = color_chart_32();
+    // cell_size=100 > 32: タイルは1つ、中心 = (50,50) を clamp(31) → 右下灰
+    let cpu_out = detail_loss_with_cell_size(img.clone(), 1.0, 100).unwrap().to_rgba8();
+    let gpu_sim = sim_detail_loss_shader_cell(&img.to_rgba8(), 100);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 60.0, "apply(DetailLoss) cell_size>image: PSNR {db:.1} dB < 60 dB");
+    // 全画素が同一色（1タイルに塗り潰し）であること
+    let first = *cpu_out.get_pixel(0, 0);
+    assert!(
+        cpu_out.pixels().all(|p| p[0] == first[0] && p[1] == first[1] && p[2] == first[2]),
+        "cell_size>image: 全 RGB が単一色になるはず"
+    );
+}
+
+/// kako-jun/sensus#96: 画像幅（32）と互いに素な cell_size=5 で端タイルが半端に切れても
+/// 中心点サンプリングシェーダと等価（端タイルでの中心 clamp が正しい）。
+#[test]
+fn shader_equiv_apply_detail_loss_coprime_cell_size_psnr() {
+    use sensus_core::vision::detail_loss_with_cell_size;
+    let img = gradient_32();
+    // gcd(32,5)=1: 端で 32 % 5 = 2px の半端タイルが残る
+    let cpu_out = detail_loss_with_cell_size(img.clone(), 1.0, 5).unwrap().to_rgba8();
+    let gpu_sim = sim_detail_loss_shader_cell(&img.to_rgba8(), 5);
+    let db = psnr(&cpu_out, &gpu_sim);
+    assert!(db >= 60.0, "apply(DetailLoss) coprime cell_size=5: PSNR {db:.1} dB < 60 dB");
+}
+
+/// kako-jun/sensus#96: 中心点方式は alpha チャンネルを変質させない。
+/// RGB はタイルごとに塗り潰されるが、各画素の alpha は入力のまま保持される。
+#[test]
+fn apply_detail_loss_preserves_alpha_per_pixel() {
+    use sensus_core::vision::detail_loss_with_cell_size;
+    let img = varying_alpha_32();
+    let orig = img.to_rgba8();
+    let out = detail_loss_with_cell_size(img.clone(), 1.0, 8).unwrap().to_rgba8();
+    // RGB は実際に変化していること（テストが無意味な identity でないことを保証）
+    assert_ne!(out.as_raw(), orig.as_raw(), "detail_loss cell_size=8 should change RGB");
+    // alpha は1画素ずつ完全一致
+    for (po, pi) in out.pixels().zip(orig.pixels()) {
+        assert_eq!(po[3], pi[3], "alpha は画素ごとに保存されるべき");
+    }
+}
+
+// ---------------------------------------------------------------------------
 // S-3: cataract strength=1.0 のクラッシュ/動作確認テスト
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 関連 Issue
closes #96

## 問題
`apply(Filter::DetailLoss)` が呼ぶ `detail_loss_with_cell_size` だけがタイル平均アルゴリズムで、GLSL シェーダ `detail_loss.frag`（universal-experience の Flutter 表示経路＝正本）と `detail_loss`（strength 版）が実装する中心点サンプリングと乖離していた。さらに shader_equivalence テストは別関数（中心点版）を検証しており、apply 経路の関数は CPU↔GLSL 等価が無検証だった。

## 変更内容
- `detail_loss_with_cell_size` をタイル平均→タイル中心点サンプリングに統一（シェーダ・strength 版と同一アルゴリズムに）
- apply 経路に対する CPU↔GLSL 等価テストを追加（cell_size=7/20、非正方形 64×32/32×64、cell_size=0 identity、画像超過、互いに素な cell_size、alpha 保存）
- shader_equivalence: 53→59 件

## 検証
- cargo test 全通過（shader_equivalence 59 / core 259 / その他 integration 全 ok）
- cargo clippy --all-targets --all-features 警告ゼロ