### PR TITLE
fix: #99 metamorphopsia/dry_eye のノイズモデルを CPU↔GLSL で統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **fix: kako-jun/sensus#99 `metamorphopsia` / `dry_eye` のノイズモデルを CPU と統一**:
+  - 両フィルタの `.frag` が CPU と別アルゴリズムのノイズモデルを使っており原理的に一致しなかった問題を解消。正本は CPU（医学的に正しく決定論的）。**option (a)** を採用し、両者を「GPU でも単一パスで bit 再現可能な 32bit 整数 spatial hash」に寄せて統一した。CPU 側の出力が変わるため CHANGELOG に明記する（下記）。
+  - **metamorphopsia**: 旧 `.frag` は `uSeed` を即 float 化し `hash2`/`smoothNoise`（`sin` ベース）で変位場を作っており、CPU の LCG グリッド変位と無関係だった。CPU・GLSL ともに「グリッド頂点ごとの決定論的変位場 + 双線形補間」に統一。変位ハッシュ `gridHash(seed, gx, gy, axis)` を CPU の `grid_hash` と完全に同じ 32bit 整数演算（黄金比定数混合 + XOR-shift finalizer、`uint` は CPU `u32` と同じく mod 2^32 で wrap）にし、`uSeed` は `uint` のまま整数演算に通す（float 化しない）。グリッド頂点インデックスは `uTexelSize` から解像度を復元して CPU と同じ整数ピクセル座標基準で算出。**CPU 変更**: 変位生成を 64bit Knuth LCG（`(state>>32)` の高位ビット抽出を含み GPU の `uint` で再現不可）から 32bit 整数 spatial hash に変更（strength=0 の identity・寸法・alpha 保持・seed 差分は不変。既存 CPU テストはバイト固定しておらず全て pass）。
+  - **dry_eye**: 旧 `.frag` は gamma sRGB サンプリング・画面 16 固定分割タイル・`hash()`・半径 `noise*s*2` で、CPU（linear sRGB・32px タイル・seed=42 LCG・半径 `*3`）と再現不可と宣言されていた。CPU・GLSL ともに「linear sRGB サンプリング・32px ピクセルタイル・seed=42 の 32bit spatial hash・半径 `noise*strength*3px`・等方 disk（pillbox）平均（メンバシップ `dx²+dy²≤r²`、edge clamp）」に統一。**CPU 変更**: タイルノイズを「行優先で走査しながら逐次更新する 64bit LCG 状態」（各タイルが先行タイル数 = グリッド寸法に依存し GPU の並列実行で再現不可）から、タイル座標だけの 32bit spatial hash に変更（strength=0 の identity は不変）。
+  - **一致根拠**: 両フィルタとも CPU と `.frag` を 1:1 でミラーする sim（`sim_metamorphopsia_glsl` / `sim_dry_eye_glsl`、実 `.frag` と同式・別アルゴリズムのインライン化なし）で検証し、テストフィクスチャ上 **PSNR = ∞（バイト完全一致）**。整数ハッシュ・補間/disk・linear sRGB が完全一致するため、残る乖離源は f32 丸めのみ（フィクスチャ上は丸め後も同一バイト）。
+  - **API 追加**: `dry_eye_uniforms(strength, width, height)` と `DryEyeUniforms`（`uTexelSize` 追加。タイル座標・disk 半径のテクスチャ座標変換に必要）。`MetamorphopsiaUniforms` は既存の `seed: u32` / `texel_size` をそのまま使用（struct 変更なし）。いずれも既存シグネチャ変更ではなく追加。
+  - CPU↔GLSL 等価テストを追加（metamorphopsia: strength 0.0/0.5/1.0・非正方形 64×32、dry_eye: strength 0.0/0.5/1.0・非正方形 64×32、いずれも PSNR ≥ 30 dB 判定で実測 ∞）。
 - **fix: kako-jun/sensus#98 `eye_strain` GLSL にブラー段を追加し等価テストの偽装を解消**:
   - `eye_strain.frag` を「contrast 圧縮 + vignette のみ」から、CPU `vision::eye_strain` と同じ処理順序（contrast → vignette → disk blur）に実装。CPU が最後に適用する半径 `strength*1.5px` の disk（pillbox）blur 段が `.frag` に欠落しており universal-experience の表示と CPU が乖離していた問題を解消
   - 単一パス制約のため厳密 pillbox を Fibonacci lattice 16 tap で近似（CPU=厳密 pillbox、これが唯一の乖離源）。各 tap で contrast+vignette を再計算してから円盤状に平均し、linear sRGB 空間で処理。PSNR で担保（32×32 で strength=0.5 → 40.0 dB、1.0 → 42.3 dB、いずれも下限 30 dB 超）

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -141,6 +141,31 @@ pub fn dry_eye_glsl() -> &'static str {
     include_str!("shaders/dry_eye.frag")
 }
 
+/// dry_eye フィルタの uniform。
+///
+/// CPU 実装 `vision::dry_eye` は 32×32 ピクセルタイルごとに seed=42 の 32bit
+/// spatial hash でノイズ値を決め、半径 `noise * strength * 3px` の等方 disk blur を
+/// linear sRGB 空間で適用する（#99 で CPU/GLSL のノイズモデルを統一）。
+/// シェーダはタイル座標とピクセル座標の算出に `uTexelSize` を必要とする。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DryEyeUniforms {
+    /// strength (0.0..=1.0)。dry_eye.frag の `uStrength` に渡す。
+    pub strength: f32,
+    /// テクセルサイズ vec2(1.0/width, 1.0/height)。dry_eye.frag の `uTexelSize` に渡す。
+    pub texel_size: [f32; 2],
+}
+
+/// dry_eye の uniform を返す。
+///
+/// `width`, `height`: 画像の幅・高さ（ピクセル）。タイル座標・disk 半径の
+/// テクスチャ座標変換に使う texel size を算出する。
+pub fn dry_eye_uniforms(strength: f32, width: u32, height: u32) -> DryEyeUniforms {
+    DryEyeUniforms {
+        strength,
+        texel_size: [1.0 / width as f32, 1.0 / height as f32],
+    }
+}
+
 /// contrast_sensitivity.frag の GLSL ES 3.00 ソースを返す。
 pub fn contrast_sensitivity_glsl() -> &'static str {
     include_str!("shaders/contrast_sensitivity.frag")
@@ -677,13 +702,18 @@ pub fn metamorphopsia_glsl() -> &'static str {
 }
 
 /// Metamorphopsia シェーダーの uniform 値。
+///
+/// CPU 実装 `vision::metamorphopsia` と同一のノイズモデル（#99 で統一）。
+/// グリッド頂点ごとの変位を 32bit 整数 spatial hash（`seed` + 頂点座標）で生成し、
+/// `metamorphopsia.frag` は `uTexelSize` から解像度を復元してグリッド頂点座標を
+/// CPU と同じ整数ピクセル基準で計算する。
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetamorphopsiaUniforms {
     /// 歪み強度（0.0..=1.0）
     pub strength: f32,
     /// 空間周波数（グリッド分割数）
     pub freq: f32,
-    /// LCG シード（uint で精度損失なく渡す）
+    /// 32bit spatial hash シード（u64 シードの下位 32bit。uint で精度損失なく渡す）
     pub seed: u32,
     /// テクセルサイズ (1/width, 1/height)
     pub texel_size: [f32; 2],

--- a/crates/core/src/shaders/dry_eye.frag
+++ b/crates/core/src/shaders/dry_eye.frag
@@ -1,42 +1,110 @@
 #version 300 es
-precision mediump float;
+precision highp float;
+precision highp int;
+
+// ドライアイ（dry eye）シミュレーション。
+// CPU 実装 vision::dry_eye と同一のノイズモデル（#99 で統一）。
+//
+// ## アルゴリズム
+// 画面を 32x32 ピクセルのタイルに分割し、各タイルに 32bit 整数 spatial hash で
+// 擬似ランダムなノイズ値 noise(0..1) を割り当てる。各フラグメントが属するタイルの
+// noise から blur 半径 = noise * uStrength * 3.0 px を決め、その半径の等方 disk
+// （pillbox）で linear sRGB 空間の近傍を平均する。半径 < 0.5px のタイルは
+// パススルー（元画像そのまま）。
+//
+// ## CPU との一致根拠
+// - `tileHash` は CPU の `tile_hash` と完全に同じ 32bit 整数演算（seed=42 固定）。
+//   GLSL の uint は CPU の u32 同様 mod 2^32 で wrap し、同じ (tx, ty) から bit 単位に
+//   同じ noise を返す。float 経由の精度損失を避けるため整数で計算する。
+// - disk のメンバシップ `dx*dx + dy*dy <= r*r`（dx,dy in -ceil(r)..=ceil(r)）と
+//   edge replication（clamp）は CPU の build_ellipse_spans(r, r, 0) と一致。
+// - 半径係数 *3.0、TILE_SIZE=32、linear sRGB サンプリングを CPU と統一。
+// - 唯一の乖離源は浮動小数丸めのみ。
+
 uniform sampler2D uTexture;
 uniform float uStrength;
+uniform vec2 uTexelSize; // vec2(1.0/width, 1.0/height)
+
 in vec2 vTexCoord;
 out vec4 fragColor;
 
-// 簡易ハッシュ関数（シェーダ内ノイズ生成用）
-float hash(vec2 p) {
-    p = fract(p * vec2(127.1, 311.7));
-    p += dot(p, p + 19.19);
-    return fract(p.x * p.y);
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+// linear sRGB でサンプリング（座標は整数ピクセル、edge clamp）。
+vec3 sampleLinear(vec2 pixelCoord, vec2 resolution) {
+    vec2 p = clamp(pixelCoord, vec2(0.0), resolution - 1.0);
+    vec2 uv = (p + 0.5) * uTexelSize;
+    vec4 c = texture(uTexture, uv);
+    return vec3(srgbToLinear(c.r), srgbToLinear(c.g), srgbToLinear(c.b));
+}
+
+// タイル座標の 32bit 整数 spatial hash（0.0..=1.0）。CPU の tile_hash と同一。
+float tileHash(uint tx, uint ty) {
+    const uint SEED = 42u;
+    uint h = SEED * 0x9e3779b9u
+        + tx * 0x85ebca6bu
+        + ty * 0xc2b2ae35u;
+    h ^= h >> 15;
+    h *= 0x2c1b3c6du;
+    h ^= h >> 12;
+    h *= 0x297a2d39u;
+    h ^= h >> 15;
+    return float(h) / float(0xFFFFFFFFu);
 }
 
 void main() {
-    // タイル座標（32x32 タイル想定）でノイズ値を決定
-    vec2 tile_coord = floor(vTexCoord * 16.0); // 画面を 16 分割
-    float noise = hash(tile_coord + vec2(42.0, 42.0));
-    float blur_amount = noise * uStrength;
+    vec4 orig = texture(uTexture, vTexCoord);
+    if (uStrength <= 0.0) {
+        fragColor = orig;
+        return;
+    }
 
-    // 近傍サンプルの平均でソフトブラーを近似
-    vec2 texel_size = vec2(1.0) / vec2(textureSize(uTexture, 0));
-    vec4 color = vec4(0.0);
-    float total = 0.0;
-    float r = blur_amount * 2.0;
-    for (int dy = -2; dy <= 2; dy++) {
-        for (int dx = -2; dx <= 2; dx++) {
-            float dist = length(vec2(float(dx), float(dy)));
-            if (dist <= r + 0.5) {
-                vec2 offset = vec2(float(dx), float(dy)) * texel_size;
-                color += texture(uTexture, vTexCoord + offset);
-                total += 1.0;
+    const float TILE_SIZE = 32.0;
+    const float MIN_BLUR_RADIUS_PX = 0.5;
+
+    vec2 resolution = vec2(1.0) / uTexelSize;
+    // CPU の整数ピクセル座標 (x, y)（top-left 規約）を復元する。
+    // フラグメント中心の uv = (x+0.5)/w なので floor(uv*w) = x。
+    vec2 pixelPos = floor(vTexCoord * resolution);
+    // タイルインデックス（CPU: x / TILE_SIZE の整数除算）。
+    uint tx = uint(floor(pixelPos.x / TILE_SIZE));
+    uint ty = uint(floor(pixelPos.y / TILE_SIZE));
+
+    float noise = tileHash(tx, ty);
+    float blurRadius = noise * uStrength * 3.0;
+
+    if (blurRadius < MIN_BLUR_RADIUS_PX) {
+        // blur なし: 元画像そのまま（CPU と同じパススルー）。
+        fragColor = orig;
+        return;
+    }
+
+    // 等方 disk（pillbox）平均。CPU build_ellipse_spans(r, r, 0) と同じメンバシップ。
+    int rMax = int(ceil(blurRadius));
+    float r2 = blurRadius * blurRadius;
+    vec3 acc = vec3(0.0);
+    float count = 0.0;
+    for (int dy = -rMax; dy <= rMax; dy++) {
+        for (int dx = -rMax; dx <= rMax; dx++) {
+            float fdx = float(dx);
+            float fdy = float(dy);
+            if (fdx * fdx + fdy * fdy <= r2) {
+                acc += sampleLinear(pixelPos + vec2(fdx, fdy), resolution);
+                count += 1.0;
             }
         }
     }
-    if (total > 0.0) {
-        color /= total;
-    } else {
-        color = texture(uTexture, vTexCoord);
-    }
-    fragColor = vec4(color.rgb, texture(uTexture, vTexCoord).a);
+    vec3 blurred = count > 0.0 ? acc / count : sampleLinear(pixelPos, resolution);
+
+    fragColor = vec4(
+        linearToSrgb(blurred.r),
+        linearToSrgb(blurred.g),
+        linearToSrgb(blurred.b),
+        orig.a
+    );
 }

--- a/crates/core/src/shaders/metamorphopsia.frag
+++ b/crates/core/src/shaders/metamorphopsia.frag
@@ -1,43 +1,47 @@
 #version 300 es
-precision mediump float;
+precision highp float;
+precision highp int;
 
-// 歪視（Metamorphopsia）シミュレーション
-// hash2D ベースの smooth noise 変位マップで各ピクセルをリマップする。
+// 歪視（Metamorphopsia）シミュレーション。
+// CPU 実装 vision::metamorphopsia と同一のノイズモデル（#99 で統一）。
+//
+// ## アルゴリズム
+// 画像を cell_size ピクセルの仮想グリッドに分割し、各グリッド頂点に
+// 32bit 整数 spatial hash で擬似ランダムな変位 (dx, dy) を割り当てる。
+// 各フラグメントが属するセルの 4 頂点の変位を双線形補間し、その変位で
+// サンプリング座標を移動して元画像をサンプリングする（エッジは clamp）。
+//
+// ## CPU との一致根拠
+// - `gridHash` は CPU の `grid_hash` と完全に同じ 32bit 整数演算（GLSL の uint は
+//   CPU の u32 と同じく mod 2^32 で wrap する）。同じ (seed, gx, gy, axis) から
+//   bit 単位に同じ 0..1 値を返す。float 経由の精度損失を避けるため uSeed は uint。
+// - グリッド頂点インデックス gx0/gy0 は CPU の整数ピクセル座標基準 (x/cell_size の
+//   floor) に合わせるため、フラグメント中心 uv からピクセル座標を
+//   `vTexCoord * resolution - 0.5` で復元する。
+// - 唯一の乖離源はサンプリング段の浮動小数丸めのみ。変位場は CPU と一致する。
 
 uniform sampler2D uTexture;
 uniform float uStrength;   // 0.0..=1.0
-uniform float uFreq;       // 空間周波数（グリッド分割数 / min(W,H)）
+uniform float uFreq;       // 空間周波数（グリッド分割数）
 uniform uint  uSeed;       // ランダムシード（uint で精度損失なく渡す）
 uniform vec2  uTexelSize;  // vec2(1.0/width, 1.0/height)
 
 in vec2 vTexCoord;
 out vec4 fragColor;
 
-// 2D hash: uv → [0, 1]^2 の擬似ランダム値
-vec2 hash2(vec2 p, float seed) {
-    p += seed * 0.001;
-    p = vec2(
-        dot(p, vec2(127.1, 311.7)),
-        dot(p, vec2(269.5, 183.3))
-    );
-    return fract(sin(p) * 43758.5453123);
-}
-
-// 格子点間を smooth hermite 補間する value noise（変位マップ用）
-vec2 smoothNoise(vec2 uv, float seed) {
-    vec2 i = floor(uv);
-    vec2 f = fract(uv);
-
-    // smoothstep（3次エルミート）
-    vec2 u = f * f * (3.0 - 2.0 * f);
-
-    vec2 a = hash2(i + vec2(0.0, 0.0), seed);
-    vec2 b = hash2(i + vec2(1.0, 0.0), seed);
-    vec2 c = hash2(i + vec2(0.0, 1.0), seed);
-    vec2 d = hash2(i + vec2(1.0, 1.0), seed);
-
-    // 双線形補間
-    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+// 1 頂点・1 軸ぶんの 32bit ハッシュ（axis: 0=dx, 1=dy）。0.0..=1.0 を返す。
+// CPU 実装 vision::metamorphopsia の grid_hash と完全に同じ系列。
+float gridHash(uint gx, uint gy, uint axis) {
+    uint h = uSeed * 0x9e3779b9u
+        + gx * 0x85ebca6bu
+        + gy * 0xc2b2ae35u
+        + axis * 0x27d4eb2fu;
+    h ^= h >> 15;
+    h *= 0x2c1b3c6du;
+    h ^= h >> 12;
+    h *= 0x297a2d39u;
+    h ^= h >> 15;
+    return float(h) / float(0xFFFFFFFFu); // 0.0..=1.0
 }
 
 void main() {
@@ -46,21 +50,44 @@ void main() {
         return;
     }
 
-    // 最大変位量（テクスチャ座標空間、8px 相当）
+    // 最大変位量（ピクセル）。CPU の MAX_DISPLACEMENT_PX と同値。
     const float MAX_DISP_PX = 8.0;
+    float maxDisp = uStrength * MAX_DISP_PX;
 
-    // ノイズ座標（周波数スケール）
-    vec2 noiseUv = vTexCoord * uFreq;
+    // 解像度を texel size から復元（width = 1/uTexelSize.x）。
+    vec2 resolution = vec2(1.0) / uTexelSize;
+    float minDim = min(resolution.x, resolution.y);
 
-    // uint uSeed を float に変換して hash2 に渡す
-    float seedF = float(uSeed);
+    // グリッドセルサイズ（CPU と同じ: max(min_dim / clamp(freq), 1.0)）。
+    float freqClamped = clamp(uFreq, 0.1, 1000.0);
+    float cellSize = max(minDim / freqClamped, 1.0);
 
-    // [-1, 1]^2 の変位ベクトルを生成
-    vec2 noise = smoothNoise(noiseUv, seedF) * 2.0 - 1.0;
+    // CPU の整数ピクセル座標 x（top-left 規約）を復元する。
+    vec2 pixelPos = vTexCoord * resolution - 0.5;
+    vec2 cell = pixelPos / cellSize;
+    vec2 ci = floor(cell);
+    float tx = cell.x - ci.x; // 0.0..=1.0 のセル内位置
+    float ty = cell.y - ci.y;
 
-    // テクスチャ座標への変位量（texel 単位 → uv 単位）
-    vec2 disp = noise * uStrength * MAX_DISP_PX * uTexelSize;
+    // グリッド頂点インデックス（CPU と同じく非負。floor は負になり得ないが念のため max）。
+    uint gx0 = uint(max(ci.x, 0.0));
+    uint gy0 = uint(max(ci.y, 0.0));
+    uint gx1 = gx0 + 1u;
+    uint gy1 = gy0 + 1u;
 
-    vec2 sampledUv = clamp(vTexCoord + disp, vec2(0.0), vec2(1.0));
+    // 4 頂点の変位 [-1,1]*maxDisp を双線形補間（CPU と同じ重み）。
+    vec2 d00 = vec2(gridHash(gx0, gy0, 0u), gridHash(gx0, gy0, 1u)) * 2.0 - 1.0;
+    vec2 d10 = vec2(gridHash(gx1, gy0, 0u), gridHash(gx1, gy0, 1u)) * 2.0 - 1.0;
+    vec2 d01 = vec2(gridHash(gx0, gy1, 0u), gridHash(gx0, gy1, 1u)) * 2.0 - 1.0;
+    vec2 d11 = vec2(gridHash(gx1, gy1, 0u), gridHash(gx1, gy1, 1u)) * 2.0 - 1.0;
+
+    vec2 disp = (d00 * (1.0 - tx) * (1.0 - ty)
+               + d10 * tx * (1.0 - ty)
+               + d01 * (1.0 - tx) * ty
+               + d11 * tx * ty) * maxDisp;
+
+    // 変位後のピクセル座標（CPU と同じく clamp でエッジ処理）→ uv に戻す。
+    vec2 sampledPx = clamp(pixelPos + disp, vec2(0.0), resolution - 1.0);
+    vec2 sampledUv = (sampledPx + 0.5) * uTexelSize;
     fragColor = texture(uTexture, sampledUv);
 }

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2242,12 +2242,15 @@ pub fn eye_strain(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
 /// 歪視（Metamorphopsia）シミュレーション。
 ///
 /// 黄斑疾患（黄斑円孔・黄斑上膜・加齢黄斑変性など）で生じる格子状の歪み（Amsler grid
-/// 歪曲）を模擬する。LCG ベースのグリッドノイズで各ピクセルを変位座標からサンプリングする。
+/// 歪曲）を模擬する。グリッド頂点ごとの決定論的ノイズで各ピクセルを変位座標から
+/// サンプリングする。
 ///
 /// ## アルゴリズム
 ///
 /// 画像を `1/freq` ピクセル単位の仮想グリッドに分割し、各グリッド頂点に
-/// LCG 擬似ランダムな変位ベクトル `(dx, dy)` を割り当てる。
+/// 32bit 整数 spatial hash で擬似ランダムな変位ベクトル `(dx, dy)` を割り当てる。
+/// ノイズは seed と頂点座標だけの決定論的関数で、`metamorphopsia.frag` の `gridHash`
+/// と bit 単位に一致する（#99 で CPU/GLSL のノイズモデルを統一）。
 /// 各出力ピクセルについて、所属するグリッドセルの 4 頂点の変位を双線形補間し、
 /// その変位でサンプリング座標を移動して元画像をサンプリングする。
 /// エッジは clamp で処理する。
@@ -2283,32 +2286,38 @@ pub fn metamorphopsia(img: DynamicImage, strength: f32, freq: f32, seed: u64) ->
     let grid_w = (width as f32 / cell_size).ceil() as usize + 2;
     let grid_h = (height as f32 / cell_size).ceil() as usize + 2;
 
-    // LCG 定数（Knuth / Numerical Recipes）
-    let lcg_step = |state: u64| -> u64 {
-        state
-            .wrapping_mul(6364136223846793005)
-            .wrapping_add(1442695040888963407)
+    // グリッド頂点ごとの変位を 32bit 整数ハッシュで生成する。
+    //
+    // #99: GLSL ES 3.00 の `uint`（32bit）で bit 単位に再現できるよう、
+    // 旧 64bit Knuth LCG（`(state>>32)` の高位ビット抽出を含む）から、
+    // 純粋な 32bit 整数 spatial hash に変更した。各頂点の値は seed と頂点座標
+    // (gx, gy) だけの決定論的関数で、逐次状態を持たない（並列・GPU 再現可能）。
+    // `metamorphopsia.frag` の `gridHash` と完全に同一の系列を出す（u32 演算は
+    // GLSL の `uint` 同様 mod 2^32 で wrap する）。
+    //
+    // 唯一の乖離源はサンプリング段の f32 丸めのみで、変位場は CPU↔GLSL で一致する。
+    let seed32 = seed as u32;
+    // 1 頂点・1 軸ぶんの 32bit ハッシュ（axis: 0=dx, 1=dy）。0.0..=1.0 を返す。
+    let grid_hash = |gx: u32, gy: u32, axis: u32| -> f32 {
+        // 各入力を 32bit 黄金比定数で混合してから XOR-shift で雪崩効果を付ける。
+        let mut h = seed32
+            .wrapping_mul(0x9e3779b9)
+            .wrapping_add(gx.wrapping_mul(0x85ebca6b))
+            .wrapping_add(gy.wrapping_mul(0xc2b2ae35))
+            .wrapping_add(axis.wrapping_mul(0x27d4eb2f));
+        h ^= h >> 15;
+        h = h.wrapping_mul(0x2c1b3c6d);
+        h ^= h >> 12;
+        h = h.wrapping_mul(0x297a2d39);
+        h ^= h >> 15;
+        h as f32 / u32::MAX as f32 // 0.0..=1.0
     };
 
-    // 各グリッド頂点の変位 (dx, dy) を LCG で生成する。
-    // シードは頂点座標とグローバルシードを混合して決定する（空間的再現性を確保）。
     let grid_disp: Vec<(f32, f32)> = (0..grid_h)
         .flat_map(|gy| (0..grid_w).map(move |gx| (gx, gy)))
         .map(|(gx, gy)| {
-            // 頂点ごとに独立したシードを生成する。
-            // seed との混合で異なる grid_size でもシードが衝突しにくい。
-            let h0 = seed
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            let h1 = h0
-                .wrapping_add((gx as u64).wrapping_mul(0x9e3779b97f4a7c15))
-                .wrapping_add((gy as u64).wrapping_mul(0x6c62272e07bb0142));
-            // dx
-            let s1 = lcg_step(h1);
-            let dx_norm = (s1 >> 32) as f32 / u32::MAX as f32; // 0.0..=1.0
-            // dy
-            let s2 = lcg_step(s1);
-            let dy_norm = (s2 >> 32) as f32 / u32::MAX as f32;
+            let dx_norm = grid_hash(gx as u32, gy as u32, 0);
+            let dy_norm = grid_hash(gx as u32, gy as u32, 1);
             // [-1, 1] に変換してから max_disp を掛ける
             let dx = (dx_norm * 2.0 - 1.0) * max_disp;
             let dy = (dy_norm * 2.0 - 1.0) * max_disp;
@@ -2367,13 +2376,18 @@ pub fn metamorphopsia(img: DynamicImage, strength: f32, freq: f32, seed: u64) ->
 
 /// ドライアイ（dry eye）シミュレーション。
 ///
-/// LCG（seed=42 固定）で生成したノイズマスクを基に、
-/// 32×32 タイルごとに異なる disk blur radius を適用する。
+/// 32bit 整数 spatial hash（seed=42 固定）で生成したタイルごとのノイズを基に、
+/// 32×32 ピクセルタイルごとに異なる等方 disk blur radius（`noise * strength * 3px`）を
+/// linear sRGB 空間で適用する。
 ///
 /// `strength = 0.0` は元画像と完全一致。
 ///
 /// シード値は内部で固定（42）のため、同一入力に対して毎回同一のノイズパターンになります。
 /// フレームごとに異なるパターンが必要な場合は将来の `dry_eye_with_seed(img, strength, seed)` を使用してください（未実装）。
+///
+/// #99: タイルノイズを行優先の逐次 64bit LCG から、タイル座標だけの決定論的 32bit
+/// spatial hash に変更した。これにより `dry_eye.frag` がフラグメント単位で同じノイズ場・
+/// 同じ disk blur を単一パスで再現でき、CPU↔GLSL が等価になった（PSNR で担保）。
 pub fn dry_eye(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
     let s = normalize_strength(strength);
     let rgba = img.to_rgba8();
@@ -2386,12 +2400,27 @@ pub fn dry_eye(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
     let (linear, alpha) = rgba_to_linear_planes(&rgba);
 
     const TILE_SIZE: u32 = 32;
+    // ドライアイの seed（固定 42）。タイルごとのノイズ生成に使う。
+    const DRY_EYE_SEED: u32 = 42;
 
-    // LCG 定数（Numerical Recipes）
-    let lcg_next = |state: u64| -> u64 {
-        state
-            .wrapping_mul(6364136223846793005)
-            .wrapping_add(1442695040888963407)
+    // タイルごとの 32bit 整数 spatial hash（0.0..=1.0）。
+    //
+    // #99: 旧実装はタイルを行優先で走査しながら 64bit LCG 状態を逐次更新していた
+    // （各タイルのノイズが先行タイル数 = タイルグリッド寸法に依存していた）。これは
+    // フラグメントシェーダの並列実行では再現できない。各タイルのノイズを seed と
+    // タイル座標 (tx, ty) だけの決定論的関数に変更し、`dry_eye.frag` の `tileHash` と
+    // 完全に同一の系列を出す（u32 演算は GLSL の uint 同様 mod 2^32 で wrap）。
+    let tile_hash = |tx: u32, ty: u32| -> f32 {
+        let mut h = DRY_EYE_SEED
+            .wrapping_mul(0x9e3779b9)
+            .wrapping_add(tx.wrapping_mul(0x85ebca6b))
+            .wrapping_add(ty.wrapping_mul(0xc2b2ae35));
+        h ^= h >> 15;
+        h = h.wrapping_mul(0x2c1b3c6d);
+        h ^= h >> 12;
+        h = h.wrapping_mul(0x297a2d39);
+        h ^= h >> 15;
+        h as f32 / u32::MAX as f32 // 0.0..=1.0
     };
 
     // タイル数を計算
@@ -2402,12 +2431,10 @@ pub fn dry_eye(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
     let mut out_linear = linear.clone();
 
     // タイルごとに disk blur を適用して出力バッファに書き込む
-    let mut state: u64 = 42u64.wrapping_mul(6364136223846793005).wrapping_add(1);
     for ty in 0..tile_rows {
         for tx in 0..tile_cols {
-            state = lcg_next(state);
-            // 0.0..=1.0 のノイズ値（nit-2: (state >> 33) as f32 / (1u64 << 31) as f32）
-            let noise = (state >> 33) as f32 / (1u64 << 31) as f32;
+            // 0.0..=1.0 のノイズ値（タイル座標の spatial hash）
+            let noise = tile_hash(tx, ty);
             let blur_radius = noise * s * 3.0;
             if blur_radius < MIN_BLUR_RADIUS_PX {
                 // blur なし: 元の値をそのままコピー（既に out_linear に入っている）

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -13,16 +13,16 @@
 
 use image::{DynamicImage, RgbaImage};
 use sensus_core::shaders::{
-    achromatopsia_uniforms, astigmatism_uniforms, deuteranopia_uniforms,
+    achromatopsia_uniforms, astigmatism_uniforms, deuteranopia_uniforms, dry_eye_uniforms,
     eye_strain_uniforms, glaucoma_uniforms, hemianopia_uniforms, hyperopia_uniforms,
-    macular_degeneration_uniforms, myopia_uniforms, photophobia_uniforms, presbyopia_uniforms,
-    protanopia_uniforms, tetrachromacy_uniforms, tritanopia_uniforms, tunnel_vision_uniforms,
-    vestibular_neuritis_uniforms,
+    macular_degeneration_uniforms, metamorphopsia_uniforms, myopia_uniforms, photophobia_uniforms,
+    presbyopia_uniforms, protanopia_uniforms, tetrachromacy_uniforms, tritanopia_uniforms,
+    tunnel_vision_uniforms, vestibular_neuritis_uniforms,
 };
 use sensus_core::vision::{
-    achromatopsia, astigmatism, deuteranopia, eye_strain, glaucoma, GlaucomaMode, hemianopia,
-    hyperopia, macular_degeneration, myopia, photophobia, presbyopia, protanopia, tetrachromacy,
-    tritanopia, tunnel_vision, vestibular_neuritis,
+    achromatopsia, astigmatism, deuteranopia, dry_eye, eye_strain, glaucoma, GlaucomaMode,
+    hemianopia, hyperopia, macular_degeneration, metamorphopsia, myopia, photophobia, presbyopia,
+    protanopia, tetrachromacy, tritanopia, tunnel_vision, vestibular_neuritis,
 };
 
 // ---------------------------------------------------------------------------
@@ -1779,6 +1779,18 @@ fn gradient_64x32() -> DynamicImage {
     DynamicImage::ImageRgba8(img)
 }
 
+/// 64×64 のグラデーション画像（複数タイルでの dry_eye / metamorphopsia 検証用）。
+fn gradient_64() -> DynamicImage {
+    let mut img = RgbaImage::new(64, 64);
+    for y in 0..64u32 {
+        for x in 0..64u32 {
+            let v = (x * 4) as u8;
+            img.put_pixel(x, y, image::Rgba([v, (v / 2).wrapping_add(y as u8), 255 - v, 255]));
+        }
+    }
+    DynamicImage::ImageRgba8(img)
+}
+
 #[test]
 fn shader_equiv_glaucoma_non_square_64x32_psnr() {
     // 非正方形（width=64, height=32, aspect=2.0）で aspect 補正が機能することを確認
@@ -2066,4 +2078,293 @@ fn shader_cataract_strength_1_runs_without_crash() {
     let out = cataract(img.clone(), 1.0, 42).unwrap().to_rgba8();
     // 出力が入力と異なること（白内障フィルタが適用されている）
     assert_ne!(out.as_raw(), img.to_rgba8().as_raw(), "cataract strength=1 should change image");
+}
+
+// ---------------------------------------------------------------------------
+// #99: metamorphopsia / dry_eye ノイズモデル統一の等価性テスト（PSNR ≥ 30 dB）
+// ---------------------------------------------------------------------------
+// CPU と GLSL を同一の 32bit 整数 spatial hash + 同一の補間/disk blur に統一した。
+// 以下の sim は実 .frag を 1:1 でミラーする（別アルゴリズムのインライン化はしない）。
+
+/// metamorphopsia.frag の `gridHash` を Rust で再現する（CPU 実装と bit 一致）。
+fn metamorphopsia_grid_hash(seed: u32, gx: u32, gy: u32, axis: u32) -> f32 {
+    let mut h = seed
+        .wrapping_mul(0x9e3779b9)
+        .wrapping_add(gx.wrapping_mul(0x85ebca6b))
+        .wrapping_add(gy.wrapping_mul(0xc2b2ae35))
+        .wrapping_add(axis.wrapping_mul(0x27d4eb2f));
+    h ^= h >> 15;
+    h = h.wrapping_mul(0x2c1b3c6d);
+    h ^= h >> 12;
+    h = h.wrapping_mul(0x297a2d39);
+    h ^= h >> 15;
+    h as f32 / u32::MAX as f32
+}
+
+/// CPU `sample_bilinear` と同じ sRGB バイト空間の双線形サンプリング（edge clamp）。
+fn sample_bilinear_srgb(img: &RgbaImage, fx: f32, fy: f32) -> [u8; 4] {
+    let w = img.width() as i32;
+    let h = img.height() as i32;
+    let x0 = fx.floor() as i32;
+    let y0 = fy.floor() as i32;
+    let x1 = x0 + 1;
+    let y1 = y0 + 1;
+    let tx = fx - x0 as f32;
+    let ty = fy - y0 as f32;
+    let get = |x: i32, y: i32| -> [f32; 4] {
+        let xi = x.clamp(0, w - 1) as u32;
+        let yi = y.clamp(0, h - 1) as u32;
+        let p = img.get_pixel(xi, yi);
+        [p[0] as f32, p[1] as f32, p[2] as f32, p[3] as f32]
+    };
+    let p00 = get(x0, y0);
+    let p10 = get(x1, y0);
+    let p01 = get(x0, y1);
+    let p11 = get(x1, y1);
+    let mut out = [0u8; 4];
+    for i in 0..4 {
+        let v = p00[i] * (1.0 - tx) * (1.0 - ty)
+            + p10[i] * tx * (1.0 - ty)
+            + p01[i] * (1.0 - tx) * ty
+            + p11[i] * tx * ty;
+        out[i] = v.round().clamp(0.0, 255.0) as u8;
+    }
+    out
+}
+
+/// metamorphopsia.frag を Rust で忠実にミラーする。
+fn sim_metamorphopsia_glsl(img: &RgbaImage, strength: f32, freq: f32, seed: u32) -> RgbaImage {
+    let (w, h) = img.dimensions();
+    if strength <= 0.0 {
+        return img.clone();
+    }
+    const MAX_DISP_PX: f32 = 8.0;
+    let max_disp = strength * MAX_DISP_PX;
+    let min_dim = w.min(h) as f32;
+    let freq_clamped = freq.clamp(0.1, 1000.0);
+    let cell_size = (min_dim / freq_clamped).max(1.0);
+
+    let mut out = img.clone();
+    for y in 0..h {
+        for x in 0..w {
+            // CPU 整数ピクセル座標を復元（フラグメント中心 uv = (x+0.5)/w）。
+            let px_pos_x = x as f32;
+            let px_pos_y = y as f32;
+            let cx = px_pos_x / cell_size;
+            let cy = px_pos_y / cell_size;
+            let ci_x = cx.floor();
+            let ci_y = cy.floor();
+            let tx = cx - ci_x;
+            let ty = cy - ci_y;
+            let gx0 = ci_x.max(0.0) as u32;
+            let gy0 = ci_y.max(0.0) as u32;
+            let gx1 = gx0 + 1;
+            let gy1 = gy0 + 1;
+
+            let d = |gx: u32, gy: u32| -> (f32, f32) {
+                (
+                    metamorphopsia_grid_hash(seed, gx, gy, 0) * 2.0 - 1.0,
+                    metamorphopsia_grid_hash(seed, gx, gy, 1) * 2.0 - 1.0,
+                )
+            };
+            let (d00x, d00y) = d(gx0, gy0);
+            let (d10x, d10y) = d(gx1, gy0);
+            let (d01x, d01y) = d(gx0, gy1);
+            let (d11x, d11y) = d(gx1, gy1);
+
+            let disp_x = (d00x * (1.0 - tx) * (1.0 - ty)
+                + d10x * tx * (1.0 - ty)
+                + d01x * (1.0 - tx) * ty
+                + d11x * tx * ty)
+                * max_disp;
+            let disp_y = (d00y * (1.0 - tx) * (1.0 - ty)
+                + d10y * tx * (1.0 - ty)
+                + d01y * (1.0 - tx) * ty
+                + d11y * tx * ty)
+                * max_disp;
+
+            let src_x = (px_pos_x + disp_x).clamp(0.0, (w - 1) as f32);
+            let src_y = (px_pos_y + disp_y).clamp(0.0, (h - 1) as f32);
+            let p = sample_bilinear_srgb(img, src_x, src_y);
+            out.put_pixel(x, y, image::Rgba(p));
+        }
+    }
+    out
+}
+
+/// dry_eye.frag の `tileHash` を Rust で再現する（CPU 実装と bit 一致）。
+fn dry_eye_tile_hash(tx: u32, ty: u32) -> f32 {
+    const SEED: u32 = 42;
+    let mut h = SEED
+        .wrapping_mul(0x9e3779b9)
+        .wrapping_add(tx.wrapping_mul(0x85ebca6b))
+        .wrapping_add(ty.wrapping_mul(0xc2b2ae35));
+    h ^= h >> 15;
+    h = h.wrapping_mul(0x2c1b3c6d);
+    h ^= h >> 12;
+    h = h.wrapping_mul(0x297a2d39);
+    h ^= h >> 15;
+    h as f32 / u32::MAX as f32
+}
+
+/// dry_eye.frag を Rust で忠実にミラーする。
+fn sim_dry_eye_glsl(img: &RgbaImage, strength: f32) -> RgbaImage {
+    let (w, h) = img.dimensions();
+    if strength <= 0.0 {
+        return img.clone();
+    }
+    const TILE_SIZE: f32 = 32.0;
+    const MIN_BLUR_RADIUS_PX: f32 = 0.5;
+
+    let sample_lin = |px: f32, py: f32| -> [f32; 3] {
+        let xi = (px.clamp(0.0, (w - 1) as f32)) as u32;
+        let yi = (py.clamp(0.0, (h - 1) as f32)) as u32;
+        let p = img.get_pixel(xi, yi);
+        [
+            srgb_to_linear(p[0] as f32 / 255.0),
+            srgb_to_linear(p[1] as f32 / 255.0),
+            srgb_to_linear(p[2] as f32 / 255.0),
+        ]
+    };
+
+    let mut out = img.clone();
+    for y in 0..h {
+        for x in 0..w {
+            let orig = *img.get_pixel(x, y);
+            let px_pos_x = x as f32;
+            let px_pos_y = y as f32;
+            let tx = (px_pos_x / TILE_SIZE).floor() as u32;
+            let ty = (px_pos_y / TILE_SIZE).floor() as u32;
+            let noise = dry_eye_tile_hash(tx, ty);
+            let blur_radius = noise * strength * 3.0;
+            if blur_radius < MIN_BLUR_RADIUS_PX {
+                continue; // passthrough
+            }
+            let r_max = blur_radius.ceil() as i32;
+            let r2 = blur_radius * blur_radius;
+            let mut acc = [0f32; 3];
+            let mut count = 0f32;
+            for dy in -r_max..=r_max {
+                for dx in -r_max..=r_max {
+                    let fdx = dx as f32;
+                    let fdy = dy as f32;
+                    if fdx * fdx + fdy * fdy <= r2 {
+                        let s = sample_lin(px_pos_x + fdx, px_pos_y + fdy);
+                        acc[0] += s[0];
+                        acc[1] += s[1];
+                        acc[2] += s[2];
+                        count += 1.0;
+                    }
+                }
+            }
+            let blurred = if count > 0.0 {
+                [acc[0] / count, acc[1] / count, acc[2] / count]
+            } else {
+                sample_lin(px_pos_x, px_pos_y)
+            };
+            out.put_pixel(
+                x,
+                y,
+                image::Rgba([
+                    (linear_to_srgb(blurred[0].clamp(0.0, 1.0)) * 255.0).round() as u8,
+                    (linear_to_srgb(blurred[1].clamp(0.0, 1.0)) * 255.0).round() as u8,
+                    (linear_to_srgb(blurred[2].clamp(0.0, 1.0)) * 255.0).round() as u8,
+                    orig[3],
+                ]),
+            );
+        }
+    }
+    out
+}
+
+#[test]
+fn shader_equiv_metamorphopsia_strength_1_0_psnr() {
+    // CPU と GLSL ミラーが同一の 32bit hash 変位場 + 同一補間で一致すること。
+    // 唯一の乖離源は sample_bilinear の f32 丸めと、最終セルの頂点 clamp 差（端のみ）。
+    let img = gradient_32();
+    let uni = metamorphopsia_uniforms(1.0, 4.0, 42, 32, 32);
+    let cpu_out = metamorphopsia(img.clone(), 1.0, 4.0, 42).unwrap().to_rgba8();
+    let glsl = sim_metamorphopsia_glsl(&img.to_rgba8(), uni.strength, uni.freq, uni.seed);
+    let db = psnr(&cpu_out, &glsl);
+    assert!(db >= 30.0, "metamorphopsia strength=1.0: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_metamorphopsia_strength_0_5_psnr() {
+    let img = gradient_32();
+    let uni = metamorphopsia_uniforms(0.5, 8.0, 7, 32, 32);
+    let cpu_out = metamorphopsia(img.clone(), 0.5, 8.0, 7).unwrap().to_rgba8();
+    let glsl = sim_metamorphopsia_glsl(&img.to_rgba8(), uni.strength, uni.freq, uni.seed);
+    let db = psnr(&cpu_out, &glsl);
+    assert!(db >= 30.0, "metamorphopsia strength=0.5: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_metamorphopsia_non_square_64x32_psnr() {
+    let img = gradient_64x32();
+    let uni = metamorphopsia_uniforms(1.0, 6.0, 123, 64, 32);
+    let cpu_out = metamorphopsia(img.clone(), 1.0, 6.0, 123).unwrap().to_rgba8();
+    let glsl = sim_metamorphopsia_glsl(&img.to_rgba8(), uni.strength, uni.freq, uni.seed);
+    let db = psnr(&cpu_out, &glsl);
+    assert!(db >= 30.0, "metamorphopsia non-square 64x32: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_metamorphopsia_strength_0_0_is_identity() {
+    // strength=0: CPU は byte-exact identity、GLSL ミラーも early return で恒等。
+    let img = gradient_32();
+    let input = img.to_rgba8();
+    let uni = metamorphopsia_uniforms(0.0, 4.0, 42, 32, 32);
+    let cpu_out = metamorphopsia(img.clone(), 0.0, 4.0, 42).unwrap().to_rgba8();
+    assert_eq!(cpu_out, input, "metamorphopsia strength=0.0: CPU が identity でない");
+    let glsl = sim_metamorphopsia_glsl(&input, uni.strength, uni.freq, uni.seed);
+    assert_eq!(glsl, input, "metamorphopsia strength=0.0: GLSL が identity でない");
+}
+
+#[test]
+fn shader_equiv_dry_eye_strength_1_0_psnr() {
+    // 64x64（複数タイル）でタイルごとに異なる blur 半径が出る。CPU と GLSL ミラーが
+    // 同一のタイルノイズ + 同一 disk blur で一致すること。
+    let img = gradient_64();
+    let cpu_out = dry_eye(img.clone(), 1.0).unwrap().to_rgba8();
+    let glsl = sim_dry_eye_glsl(&img.to_rgba8(), 1.0);
+    let db = psnr(&cpu_out, &glsl);
+    assert!(db >= 30.0, "dry_eye strength=1.0: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_dry_eye_strength_0_5_psnr() {
+    let img = gradient_64();
+    let cpu_out = dry_eye(img.clone(), 0.5).unwrap().to_rgba8();
+    let glsl = sim_dry_eye_glsl(&img.to_rgba8(), 0.5);
+    let db = psnr(&cpu_out, &glsl);
+    assert!(db >= 30.0, "dry_eye strength=0.5: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_dry_eye_non_square_64x32_psnr() {
+    let img = gradient_64x32();
+    let cpu_out = dry_eye(img.clone(), 1.0).unwrap().to_rgba8();
+    let glsl = sim_dry_eye_glsl(&img.to_rgba8(), 1.0);
+    let db = psnr(&cpu_out, &glsl);
+    assert!(db >= 30.0, "dry_eye non-square 64x32: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn shader_equiv_dry_eye_strength_0_0_is_identity() {
+    let img = gradient_64();
+    let input = img.to_rgba8();
+    let cpu_out = dry_eye(img.clone(), 0.0).unwrap().to_rgba8();
+    assert_eq!(cpu_out, input, "dry_eye strength=0.0: CPU が identity でない");
+    let glsl = sim_dry_eye_glsl(&input, 0.0);
+    assert_eq!(glsl, input, "dry_eye strength=0.0: GLSL が identity でない");
+}
+
+#[test]
+fn dry_eye_uniforms_texel_size_matches_resolution() {
+    // dry_eye_uniforms が texel_size = 1/解像度 を返すこと（frag が解像度復元に使う）。
+    let uni = dry_eye_uniforms(0.7, 64, 32);
+    assert_eq!(uni.strength, 0.7);
+    assert!((uni.texel_size[0] - 1.0 / 64.0).abs() < 1e-7);
+    assert!((uni.texel_size[1] - 1.0 / 32.0).abs() < 1e-7);
 }

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -2368,3 +2368,193 @@ fn dry_eye_uniforms_texel_size_matches_resolution() {
     assert!((uni.texel_size[0] - 1.0 / 64.0).abs() < 1e-7);
     assert!((uni.texel_size[1] - 1.0 / 32.0).abs() < 1e-7);
 }
+
+// ---------------------------------------------------------------------------
+// #99 追加: 端差・境界・効果・seed のピンポイント検証
+// （上の strength 0/0.5/1.0・非正方形・identity と重複しない観点のみ）
+// ---------------------------------------------------------------------------
+
+/// 単色画像（任意サイズ）。effect/passthrough 判定用。
+fn solid_rgba(w: u32, h: u32, color: [u8; 4]) -> DynamicImage {
+    let mut img = RgbaImage::new(w, h);
+    for p in img.pixels_mut() {
+        *p = image::Rgba(color);
+    }
+    DynamicImage::ImageRgba8(img)
+}
+
+/// 任意サイズの linear グラデーション（128×128 や 32 非倍数サイズ用）。
+fn gradient_wh(w: u32, h: u32) -> DynamicImage {
+    let mut img = RgbaImage::new(w, h);
+    for y in 0..h {
+        for x in 0..w {
+            let v = ((x * 256 / w) as u8).wrapping_add((y * 64 / h) as u8);
+            img.put_pixel(x, y, image::Rgba([v, v.wrapping_mul(3), 255 - v, 255]));
+        }
+    }
+    DynamicImage::ImageRgba8(img)
+}
+
+/// 1ピクセルあたりの RGB 最大絶対差。効果量・境界の上限/下限確認に使う。
+fn max_abs_rgb_diff(a: &RgbaImage, b: &RgbaImage) -> u8 {
+    assert_eq!(a.dimensions(), b.dimensions());
+    let mut m = 0u8;
+    for (pa, pb) in a.pixels().zip(b.pixels()) {
+        for c in 0..3 {
+            m = m.max((pa[c] as i32 - pb[c] as i32).unsigned_abs() as u8);
+        }
+    }
+    m
+}
+
+#[test]
+fn shader_equiv_metamorphopsia_edge_clamp_diff_is_bounded() {
+    // 実装担当が「最終セルで CPU は頂点を grid_w-1 に clamp、GLSL は未 clamp」と報告した
+    // 端差を、画像端（上下端の行・左右端の列）の画素差分上限として検証する。
+    //
+    // 実態: CPU の grid 頂点数は ceil(dim/cell)+2 と +2 余分にパディングしてあり、
+    // 実使用される最大頂点インデックス gx1 = floor((dim-1)/cell)+1 は常に grid_w-1
+    // 未満なので get_grid の clamp は発火しない。したがって CPU と GLSL（未 clamp）の
+    // 変位場は端でも一致し、差は f32 丸めのみに収まる（本ケースの実測は端 RGB 差 0）。
+    // 上限を固定して、将来 clamp が実害化したら検知できるようにする。
+    let img = gradient_32().to_rgba8();
+    let uni = metamorphopsia_uniforms(1.0, 4.0, 42, 32, 32);
+    let cpu = metamorphopsia(DynamicImage::ImageRgba8(img.clone()), 1.0, 4.0, 42)
+        .unwrap()
+        .to_rgba8();
+    let glsl = sim_metamorphopsia_glsl(&img, uni.strength, uni.freq, uni.seed);
+    let (w, h) = img.dimensions();
+
+    let mut edge_max = 0u8;
+    for y in 0..h {
+        for x in 0..w {
+            if x == 0 || x == w - 1 || y == 0 || y == h - 1 {
+                let pc = cpu.get_pixel(x, y);
+                let pg = glsl.get_pixel(x, y);
+                for c in 0..3 {
+                    edge_max =
+                        edge_max.max((pc[c] as i32 - pg[c] as i32).unsigned_abs() as u8);
+                }
+            }
+        }
+    }
+    // f32 丸めのみなら端でも数階調以内。clamp が実害化すると変位 1px=多階調ずれる。
+    assert!(
+        edge_max <= 4,
+        "metamorphopsia の端 clamp 差が大きすぎる: 端画素 RGB 最大差 {edge_max} (>4)。\
+         CPU の頂点 clamp が GLSL 未 clamp と乖離している疑い"
+    );
+}
+
+#[test]
+fn shader_equiv_metamorphopsia_large_128_psnr() {
+    // 128×128（多数セル）でも近似が破綻しないこと。
+    let img = gradient_wh(128, 128);
+    let uni = metamorphopsia_uniforms(1.0, 12.0, 99, 128, 128);
+    let cpu = metamorphopsia(img.clone(), 1.0, 12.0, 99).unwrap().to_rgba8();
+    let glsl = sim_metamorphopsia_glsl(&img.to_rgba8(), uni.strength, uni.freq, uni.seed);
+    let db = psnr(&cpu, &glsl);
+    assert!(db >= 30.0, "metamorphopsia 128x128: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn metamorphopsia_different_seed_changes_displacement() {
+    // 異なる seed が異なる変位場を生む（seed が実際にハッシュに効いている）こと。
+    let img = gradient_32();
+    let a = metamorphopsia(img.clone(), 1.0, 4.0, 1).unwrap().to_rgba8();
+    let b = metamorphopsia(img.clone(), 1.0, 4.0, 2).unwrap().to_rgba8();
+    assert_ne!(
+        a.as_raw(),
+        b.as_raw(),
+        "metamorphopsia: seed=1 と seed=2 の出力が同一（seed がノイズに効いていない）"
+    );
+}
+
+#[test]
+fn metamorphopsia_strength_1_changes_image() {
+    // strength=1.0 で出力が入力と十分に異なる（identity 偽陽性の排除）。
+    // 単色だと変位しても画素が変わらないためグラデーションを使う。
+    let img = gradient_32();
+    let input = img.to_rgba8();
+    let out = metamorphopsia(img.clone(), 1.0, 4.0, 42).unwrap().to_rgba8();
+    let d = max_abs_rgb_diff(&out, &input);
+    assert!(
+        d >= 8,
+        "metamorphopsia strength=1.0 が入力をほぼ変えていない (最大 RGB 差 {d} < 8)"
+    );
+}
+
+#[test]
+fn shader_equiv_dry_eye_non_multiple_of_32_psnr() {
+    // 幅・高さとも 32 の倍数でないサイズ（50×50, 33×17）で半端タイル列・行が一致すること。
+    for (w, h) in [(50u32, 50u32), (33u32, 17u32)] {
+        let img = gradient_wh(w, h);
+        let cpu = dry_eye(img.clone(), 1.0).unwrap().to_rgba8();
+        let glsl = sim_dry_eye_glsl(&img.to_rgba8(), 1.0);
+        let db = psnr(&cpu, &glsl);
+        assert!(db >= 30.0, "dry_eye {w}x{h}: PSNR {db:.1} dB < 30 dB");
+    }
+}
+
+#[test]
+fn shader_equiv_dry_eye_large_128_psnr() {
+    // 128×128（4×4=16 タイル）でも近似が破綻しないこと。
+    let img = gradient_wh(128, 128);
+    let cpu = dry_eye(img.clone(), 1.0).unwrap().to_rgba8();
+    let glsl = sim_dry_eye_glsl(&img.to_rgba8(), 1.0);
+    let db = psnr(&cpu, &glsl);
+    assert!(db >= 30.0, "dry_eye 128x128: PSNR {db:.1} dB < 30 dB");
+}
+
+#[test]
+fn dry_eye_tile_passthrough_boundary_straddles_min_radius() {
+    // タイルノイズ * strength * 3px が MIN_BLUR_RADIUS_PX(0.5) を跨ぐ境界の検証。
+    // 8x8 タイルぶんの tile_hash を CPU と同一式で評価し、passthrough(<0.5px) と
+    // blur(>=0.5px) の両タイルが共存することを確認する（radius 係数 *3・閾値 0.5 が
+    // 実際に境界として機能している）。
+    let mut saw_passthrough = false;
+    let mut saw_blur = false;
+    for ty in 0..8u32 {
+        for tx in 0..8u32 {
+            let r = dry_eye_tile_hash(tx, ty) * 1.0 * 3.0;
+            if r < 0.5 {
+                saw_passthrough = true;
+            } else {
+                saw_blur = true;
+            }
+            assert!((0.0..=3.0).contains(&r), "blur 半径が想定範囲外: {r}");
+        }
+    }
+    assert!(
+        saw_passthrough && saw_blur,
+        "8x8 タイル内に passthrough と blur の両方が現れるべき \
+         (passthrough={saw_passthrough}, blur={saw_blur})"
+    );
+}
+
+#[test]
+fn dry_eye_strength_1_changes_image() {
+    // strength=1.0 で出力が入力と十分に異なる（identity 偽陽性の排除）。
+    // 単色は blur 不変なのでグラデーションを使う。
+    let img = gradient_wh(64, 64);
+    let input = img.to_rgba8();
+    let out = dry_eye(img.clone(), 1.0).unwrap().to_rgba8();
+    let d = max_abs_rgb_diff(&out, &input);
+    assert!(
+        d >= 4,
+        "dry_eye strength=1.0 が入力をほぼ変えていない (最大 RGB 差 {d} < 4)"
+    );
+}
+
+#[test]
+fn dry_eye_solid_color_is_invariant_under_blur() {
+    // 単色画像は disk blur で値が変わらない（境界 clamp 込みで平均=元色）。
+    // dry_eye の disk blur が「平均」として正しく、色を破壊しないことを保証する。
+    let input = solid_rgba(64, 64, [123, 200, 77, 255]);
+    let out = dry_eye(input.clone(), 1.0).unwrap().to_rgba8();
+    let d = max_abs_rgb_diff(&out, &input.to_rgba8());
+    assert!(
+        d <= 1,
+        "dry_eye が単色を変化させた (最大 RGB 差 {d} > 1)。disk blur の平均が不正"
+    );
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -109,12 +109,15 @@ let result = Pipeline::new()
   `smoothstep(0.3, 1.2, d)` where `d = uv·uv` with `uv ∈ [-1, 1]²`. Both CPU
   and GLSL implementations operate in linear sRGB space and apply identical
   vignette math, verified by PSNR ≥ 30 dB equivalence test.
-- **`dry_eye`**: Applies random per-tile disk blur (tile = 32×32 px). Each
-  tile's blur radius is determined by a fixed-seed (42) LCG. Only the tile
-  region (with a blur-radius overlap) is blurred rather than the full image,
-  making processing O(tile_area × kernel_height) instead of O(W×H × kernel_height).
-  Because the blur radius varies spatially per tile with a fixed seed, this
-  filter is not amenable to a GLSL equivalence test.
+- **`dry_eye`**: Applies random per-tile disk blur (tile = 32×32 px) in linear
+  sRGB space. Each tile's blur radius is `noise × strength × 3 px`, where
+  `noise ∈ [0,1]` comes from a fixed-seed (42) 32-bit integer spatial hash of
+  the tile coordinates. (#99) The CPU and GLSL implementations now share the
+  identical hash and isotropic disk (pillbox) membership (`dx²+dy² ≤ r²`,
+  edge clamp), so the filter is verified by a CPU↔GLSL equivalence test
+  (PSNR ≥ 30 dB; byte-exact on the test fixtures). The earlier sequential-LCG
+  noise (which depended on tile-scan order and could not be reproduced by a
+  parallel fragment shader) was replaced by the per-tile spatial hash.
 
 ## Contrast Sensitivity filter (#56)
 


### PR DESCRIPTION
## 関連 Issue
closes #99

## 問題
- metamorphopsia: CPU は LCG グリッド変位、.frag は sin ベース hash2 で完全に別モデル。等価不能。
- dry_eye: CPU は linear sRGB・32px タイル・seed42 逐次 LCG・半径*3、.frag は gamma 空間・16固定分割・hash・半径*2。「再現不可」と宣言されたまま。

## 変更内容（正本=CPU、ただし GPU 単一パス再現のため CPU 側も変更）
- 両フィルタのノイズを **GPU で bit 再現可能な 32bit spatial hash**（黄金比定数混合 + XOR-shift finalizer）に統一。逐次 LCG / sin hash を廃止
- metamorphopsia: グリッド頂点ごとの決定論的 spatial hash 変位 + 双線形補間。uSeed は uint のまま整数演算
- dry_eye: linear sRGB・32px ピクセルタイル・seed42 spatial hash・半径*3・等方 disk（CPU build_ellipse_spans と同一メンバシップ）に .frag を統一
- `DryEyeUniforms`/`dry_eye_uniforms` 新設。sim_metamorphopsia_glsl/sim_dry_eye_glsl を .frag 忠実ミラーとして追加
- docs/overview.md の dry_eye「GLSL 等価不可」記述を更新

## CPU 変更の影響
変位/ノイズパターンは変わるが、strength=0 identity・寸法・alpha 保持・seed 差分は不変で既存 CPU テスト全 pass（バイト固定 golden なし）。

## 検証
- cargo test --test shader_equivalence: 92 passed / 0 failed。両フィルタ strength 0/0.5/1.0・非正方形・128px・半端タイル・端 clamp 差・効果アサートすべて **PSNR=∞（bit 完全一致）**
- metamorphopsia 端 clamp 差は実測0（CPU のグリッドが+2パディングで clamp はデッドコード）
- glslangValidator で両 .frag が ES 3.00 構文 OK、cargo clippy 警告ゼロ