### PR TITLE
feat: #102 ミソフォニア（misophonia）聴覚フィルタを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **feat: kako-jun/sensus#102 ミソフォニア（misophonia）聴覚フィルタを追加**: 仕様リーフ（sensus.md）に挙がっていたが未実装だった移植漏れを解消。`HearingFilter::Misophonia { freq_hz }` + `hearing::misophonia()`。ハイパーアクーシス（[`hyperacusis`] = 全帯域一様増幅）と違い、`freq_hz` 中心のトリガー帯域（band-reject の補集合）だけを最大 6 倍ブースト + tanh 倍音歪みで耳障り化し、帯域外は残す。この帯域選択性を効果アサートテスト（`misophonia_is_band_selective`: トリガー帯域 2 kHz の RMS 変化 > 帯域外 200 Hz の RMS 変化）で固定。strength=0 恒等 / 空バッファ / ステレオ保持も検証。
+
 ### Docs
 
 - **docs: kako-jun/sensus#101 README を v0.4 に更新**: version 表記と `sensus-core` 依存 pin を `0.1` → `0.4` に更新。hearing を「(soon) / Phase 4」から「11 フィルタ実装済み（ライブラリ API 専用、CLI 非対応・#105 で追跡）」に修正。vision フィルタ表を実装済みの全フィルタ（balance/vertigo・eye fatigue 等を含む）に追従。GLSL シェーダの解像度依存 uniform（`uRadiusPx` / `uTexelSize`）を外部ホストで使う際は `*_uniforms()` ヘルパの値を設定する必要がある旨を consumer 向けに明記。

--- a/crates/core/src/hearing.rs
+++ b/crates/core/src/hearing.rs
@@ -310,6 +310,51 @@ pub fn hyperacusis(buf: AudioBuffer, strength: f32) -> AudioBuffer {
     }
 }
 
+/// 聴覚過敏・ミソフォニア（misophonia）シミュレーション。
+///
+/// ハイパーアクーシス（[`hyperacusis`]）が音量全体への耐性低下なのに対し、
+/// ミソフォニアは**特定のトリガー音への強い不快感**であり、全体ではなく
+/// 特定周波数帯だけが過剰に大きく・耳障りに知覚される。
+///
+/// そこで `freq_hz` を中心とするトリガー帯域だけを抜き出して
+/// 強調（最大 6 倍ブースト）＋ tanh 倍音歪みで耳障り化し、帯域外はそのまま残す。
+/// この帯域選択性が hyperacusis（全帯域一様増幅）との違い。
+///
+/// `freq_hz`: 不快に感じるトリガー音の中心周波数（咀嚼音・打鍵音などは概ね 1–4 kHz）。
+/// `strength = 0.0` は元音声と同一。
+pub fn misophonia(buf: AudioBuffer, strength: f32, freq_hz: f32) -> AudioBuffer {
+    let s = strength.clamp(0.0, 1.0);
+    if s == 0.0 {
+        return buf;
+    }
+    let sr = buf.sample_rate;
+    // トリガー帯域幅。中心周波数の半分（最低 500 Hz）を採り、低中音の咀嚼音も拾えるようにする。
+    let bandwidth = (freq_hz.abs() * 0.5).clamp(500.0, 2000.0);
+    // band-reject でトリガー帯域を除いた成分（帯域外）を得る。
+    let rejected = apply_biquad_all_channels(&buf, || band_reject_biquad(freq_hz, bandwidth, sr));
+
+    // トリガー帯域成分 = 元信号 − 帯域外成分。これをブーストし tanh で耳障りに歪ませる。
+    let boost = 1.0 + s * 5.0; // 1.0 → 6.0
+    let drive = 1.0 + s * 3.0;
+    let reconstructed: Vec<f32> = buf
+        .samples
+        .iter()
+        .zip(rejected.iter())
+        .map(|(&orig, &rest)| {
+            let band = orig - rest; // トリガー帯域成分
+            let harsh = (band * drive).tanh(); // 倍音歪みで耳障り化
+            let aversive = harsh * boost; // 過剰増幅
+            (rest + aversive).clamp(-1.0, 1.0)
+        })
+        .collect();
+
+    AudioBuffer {
+        samples: blend(&buf.samples, &reconstructed, s),
+        sample_rate: buf.sample_rate,
+        channels: buf.channels,
+    }
+}
+
 /// 変音（paracusis）シミュレーション。
 ///
 /// ソフトクリッピング（3次倍音歪み）で金属的・歪んだ質感を付加する。
@@ -909,5 +954,63 @@ mod tests {
         let out_rms = rms(&out.samples);
         let rel_diff = (out_rms - orig_rms).abs() / orig_rms.max(1e-6);
         assert!(rel_diff > 0.1, "amusia strength=1 must significantly attenuate 4 kHz signal (rel_diff={rel_diff})");
+    }
+
+    // ---------------------------------------------------------------
+    // Issue #102: misophonia
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn misophonia_strength_zero_is_identity() {
+        let buf = sine_wave(2000.0, 1000, 44100);
+        let orig = buf.samples.clone();
+        let out = misophonia(buf, 0.0, 2000.0);
+        assert_eq!(out.samples, orig, "misophonia strength=0 should be byte-exact identity");
+    }
+
+    #[test]
+    fn misophonia_empty_buffer_does_not_panic() {
+        let buf = AudioBuffer { samples: vec![], sample_rate: 44100, channels: 1 };
+        let out = misophonia(buf, 1.0, 2000.0);
+        assert!(out.samples.is_empty());
+    }
+
+    #[test]
+    fn misophonia_stereo_preserves_channel_count() {
+        let buf = AudioBuffer { samples: vec![0.1; 2000], sample_rate: 44100, channels: 2 };
+        let out = misophonia(buf, 1.0, 2000.0);
+        assert_eq!(out.channels, 2);
+        assert_eq!(out.samples.len(), 2000);
+    }
+
+    #[test]
+    fn misophonia_strength_one_differs_from_input() {
+        // トリガー周波数のサイン波は強調・歪みで RMS が変化する
+        let buf = sine_wave(2000.0, 44100, 44100);
+        let orig_rms = rms(&buf.samples);
+        let out = misophonia(buf, 1.0, 2000.0);
+        let out_rms = rms(&out.samples);
+        let rel_diff = (out_rms - orig_rms).abs() / orig_rms.max(1e-6);
+        assert!(rel_diff > 0.05, "misophonia strength=1 must alter the trigger-band signal (rel_diff={rel_diff})");
+    }
+
+    #[test]
+    fn misophonia_is_band_selective() {
+        // トリガー帯域内（2000 Hz）の方が帯域外（200 Hz）より強く影響を受ける
+        // ＝ hyperacusis（全帯域一様）との違いを検証する
+        let in_band = sine_wave(2000.0, 44100, 44100);
+        let in_orig = rms(&in_band.samples);
+        let in_out = rms(&misophonia(in_band, 1.0, 2000.0).samples);
+        let delta_in = (in_out - in_orig).abs() / in_orig.max(1e-6);
+
+        let out_band = sine_wave(200.0, 44100, 44100);
+        let out_orig = rms(&out_band.samples);
+        let out_out = rms(&misophonia(out_band, 1.0, 2000.0).samples);
+        let delta_out = (out_out - out_orig).abs() / out_orig.max(1e-6);
+
+        assert!(
+            delta_in > delta_out,
+            "trigger-band (2 kHz) must be affected more than out-of-band (200 Hz): delta_in={delta_in}, delta_out={delta_out}"
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -152,6 +152,8 @@ pub enum HearingFilter {
     Tinnitus { freq_hz: f32 },
     /// 音響過敏: 音量を異常に増幅
     Hyperacusis,
+    /// ミソフォニア（聴覚過敏 / 特定音への強い不快）: `freq_hz` 中心のトリガー帯域だけを過剰増幅 + 歪み
+    Misophonia { freq_hz: f32 },
     /// 変音: 音を歪んだ・金属的な質感に加工
     Paracusis,
     /// 音楽音痴: 音程の違いを識別しにくくする
@@ -186,6 +188,7 @@ pub fn apply_hearing(
         }
         HearingFilter::Tinnitus { freq_hz } => hearing::tinnitus(buf, strength, freq_hz),
         HearingFilter::Hyperacusis => hearing::hyperacusis(buf, strength),
+        HearingFilter::Misophonia { freq_hz } => hearing::misophonia(buf, strength, freq_hz),
         HearingFilter::Paracusis => hearing::paracusis(buf, strength),
         HearingFilter::Amusia => hearing::amusia(buf, strength),
         HearingFilter::Dysmelodia => hearing::dysmelodia(buf, strength),


### PR DESCRIPTION
## 概要
統合前監査（freeza session519）で検出した P1 移植漏れ #102 を解消。仕様リーフに挙がっていた Misophonia が `HearingFilter` enum に variant も関数も無かった。

## 変更
- `hearing::misophonia(buf, strength, freq_hz)` 追加
- `HearingFilter::Misophonia { freq_hz }` + `apply_hearing` 配線
- CHANGELOG

## 設計
ハイパーアクーシス（`hyperacusis` = 全帯域一様増幅 = 音量過敏）と区別。ミソフォニアは**特定トリガー音への嫌悪**なので、`freq_hz` 中心のトリガー帯域（band-reject の補集合）だけを最大6倍ブースト + tanh 倍音歪みで耳障り化し、帯域外はそのまま残す。

## テスト
- strength=0 byte-exact 恒等 / 空バッファ / ステレオ ch 保持
- strength=1 でトリガー帯域信号が変化
- **band 選択性**: トリガー帯域(2kHz) の RMS 変化 > 帯域外(200Hz) の RMS 変化（hyperacusis との差を機械保証）

closes #102