### PR TITLE
feat: #103 メニエール病フィルタ + Experience 複合記述子

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **feat: kako-jun/sensus#103 メニエール病フィルタ + `Experience` 複合記述子を追加**: 仕様の三徴候「回転性めまい + 低音域難聴 + 低い唸る耳鳴り」のうち、フィルタ自体が存在しなかった移植漏れを解消。
+  - `hearing::meniere()` + `HearingFilter::Meniere`: 聴覚側を合成。**低音域**感音難聴（メニエールの特徴。加齢性 = 高音カットの `hearing_loss` とは逆向き。100→800 Hz ハイパスの部分ブレンド）+ ~200 Hz の低い唸る耳鳴り。低音(60 Hz)が高音(2 kHz)より強く減衰することを効果アサート（`meniere_attenuates_low_more_than_high`）。
+  - `Experience { id, vision: Option<Filter>, hearing: Option<HearingFilter>, urgency: Urgency }`: 視覚と聴覚にまたがる複合体験の正準記述子。sensus は pure・別バッファ（画像/音声）アーキテクチャで単一バッファに複合症状を持てないため、「どの視覚フィルタとどの聴覚フィルタを組にすれば仕様どおりか」をライブラリ側で正準化し、consumer（universal-experience GUI 等）が組み合わせをハードコードせず取得できるようにした。`Experience::MENIERE`（Vertigo + Meniere + 早期受診）。`apply_vision()` / `apply_audio()` は欠けた modality で `Ok(None)`。
+  - `Urgency { None, EarlyConsultation, Emergency }`: 受診喚起の緊急度分類。局所化文字列を core に埋めず分類のみ保持し、consumer 側で i18n メッセージを出し分けられる設計。
 - **feat: kako-jun/sensus#102 ミソフォニア（misophonia）聴覚フィルタを追加**: 仕様リーフ（sensus.md）に挙がっていたが未実装だった移植漏れを解消。`HearingFilter::Misophonia { freq_hz }` + `hearing::misophonia()`。ハイパーアクーシス（[`hyperacusis`] = 全帯域一様増幅）と違い、`freq_hz` 中心のトリガー帯域（band-reject の補集合）だけを最大 6 倍ブースト + tanh 倍音歪みで耳障り化し、帯域外は残す。この帯域選択性を効果アサートテスト（`misophonia_is_band_selective`: トリガー帯域 2 kHz の RMS 変化 > 帯域外 200 Hz の RMS 変化）で固定。strength=0 恒等 / 空バッファ / ステレオ保持も検証。
 
 ### Docs

--- a/crates/core/src/hearing.rs
+++ b/crates/core/src/hearing.rs
@@ -652,6 +652,36 @@ pub fn auditory_processing_disorder(buf: AudioBuffer, strength: f32) -> AudioBuf
     }
 }
 
+/// メニエール病（Ménière's disease）の聴覚側シミュレーション。
+///
+/// メニエール病の三徴候は「変動性の低音域感音難聴 + 低い唸るような耳鳴り + 回転性めまい」。
+/// めまい（視覚側）は [`crate::Filter::Vertigo`] が担当し、[`crate::Experience::MENIERE`]
+/// で視覚と組として正準化される。本関数は聴覚側の二要素を合成する:
+///
+/// 1. 低音域感音難聴: ハイパスで低域を部分的に減衰させる。メニエールは高音ではなく
+///    **低音**が落ちるのが特徴で、加齢性難聴（[`hearing_loss`] = 高音カット）とは逆。
+/// 2. 低い唸る耳鳴り: ~200 Hz の正弦波をミックス（高音の `tinnitus` とは音色が異なる）。
+///
+/// `strength = 0.0` は元音声と同一。
+pub fn meniere(buf: AudioBuffer, strength: f32) -> AudioBuffer {
+    let s = strength.clamp(0.0, 1.0);
+    if s == 0.0 {
+        return buf;
+    }
+    let sr = buf.sample_rate;
+    // 1) 低音域感音難聴: 100→800 Hz のハイパスを部分ブレンド（完全除去はしない）。
+    let hp_cut = 100.0 + s * 700.0;
+    let hp = apply_biquad_all_channels(&buf, || high_pass_biquad(hp_cut, sr));
+    let low_loss = blend(&buf.samples, &hp, s * 0.7);
+    let stage1 = AudioBuffer {
+        samples: low_loss,
+        sample_rate: buf.sample_rate,
+        channels: buf.channels,
+    };
+    // 2) 低音の唸る耳鳴り（~200 Hz）。
+    tinnitus(stage1, s, 200.0)
+}
+
 // ---------------------------------------------------------------
 // テスト
 // ---------------------------------------------------------------
@@ -992,6 +1022,57 @@ mod tests {
         let out_rms = rms(&out.samples);
         let rel_diff = (out_rms - orig_rms).abs() / orig_rms.max(1e-6);
         assert!(rel_diff > 0.05, "misophonia strength=1 must alter the trigger-band signal (rel_diff={rel_diff})");
+    }
+
+    // ---------------------------------------------------------------
+    // Issue #103: meniere
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn meniere_strength_zero_is_identity() {
+        let buf = sine_wave(440.0, 1000, 44100);
+        let orig = buf.samples.clone();
+        let out = meniere(buf, 0.0);
+        assert_eq!(out.samples, orig, "meniere strength=0 should be byte-exact identity");
+    }
+
+    #[test]
+    fn meniere_empty_buffer_does_not_panic() {
+        let buf = AudioBuffer { samples: vec![], sample_rate: 44100, channels: 1 };
+        let out = meniere(buf, 1.0);
+        assert!(out.samples.is_empty());
+    }
+
+    #[test]
+    fn meniere_stereo_preserves_channel_count() {
+        let buf = AudioBuffer { samples: vec![0.1; 2000], sample_rate: 44100, channels: 2 };
+        let out = meniere(buf, 1.0);
+        assert_eq!(out.channels, 2);
+        assert_eq!(out.samples.len(), 2000);
+    }
+
+    #[test]
+    fn meniere_adds_low_tinnitus_to_silence() {
+        // 無音に低音の唸る耳鳴りが加わるので RMS > 0
+        let buf = silence(44100, 44100, 1);
+        let out = meniere(buf, 1.0);
+        assert!(rms(&out.samples) > 0.0, "meniere should add roaring tinnitus to silence");
+    }
+
+    #[test]
+    fn meniere_attenuates_low_more_than_high() {
+        // 低音域感音難聴: 低音(60 Hz)は減衰するが高音(2 kHz)はハイパスを通過する。
+        // tinnitus が一律に低音を加えても、低音入力の方が RMS 保持率が低くなることで検証する。
+        let low = sine_wave(60.0, 44100, 44100);
+        let low_ratio = rms(&meniere(low.clone(), 1.0).samples) / rms(&low.samples).max(1e-6);
+
+        let high = sine_wave(2000.0, 44100, 44100);
+        let high_ratio = rms(&meniere(high.clone(), 1.0).samples) / rms(&high.samples).max(1e-6);
+
+        assert!(
+            low_ratio < high_ratio,
+            "meniere must attenuate low freq more than high: low_ratio={low_ratio}, high_ratio={high_ratio}"
+        );
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -166,6 +166,9 @@ pub enum HearingFilter {
     Diplacusis,
     /// APD（聴覚情報処理障害）: 時間分解能低下 + 雑音付加
     AuditoryProcessingDisorder,
+    /// メニエール病の聴覚側: 低音域難聴 + 低い唸る耳鳴り（複合）。
+    /// 回転性めまい（視覚）と組で [`Experience::MENIERE`] として正準化される。
+    Meniere,
 }
 
 /// 聴覚フィルタを音声バッファに適用する。
@@ -197,6 +200,132 @@ pub fn apply_hearing(
         HearingFilter::AuditoryProcessingDisorder => {
             hearing::auditory_processing_disorder(buf, strength)
         }
+        HearingFilter::Meniere => hearing::meniere(buf, strength),
     };
     Ok(out)
+}
+
+/// 受診喚起の緊急度分類（仕様リーフの「緊急度分類」に対応）。
+///
+/// 局所的な i18n 文字列を core に埋め込まず、consumer 側で適切な言語のメッセージを
+/// 出し分けられるよう、分類だけを表す。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Urgency {
+    /// 緊急性の注記なし
+    None,
+    /// ⚠️ 早期受診が望ましい
+    EarlyConsultation,
+    /// 🚨 即救急（脳卒中等のサインの可能性）
+    Emergency,
+}
+
+/// 視覚と聴覚にまたがる「複合体験」の正準記述子。
+///
+/// sensus は pure・別バッファ（画像 / 音声）アーキテクチャのため、メニエール病のような
+/// 「回転性めまい（視覚）＋ 難聴・耳鳴り（聴覚）」の複合症状を 1 つのバッファでは表せない。
+/// `Experience` は「どの視覚フィルタとどの聴覚フィルタを組にすれば仕様どおりの複合体験になるか」を
+/// ライブラリ側で正準化する。consumer（universal-experience の GUI 等）は三徴候の組み合わせを
+/// ハードコードせず、`Experience` から視覚・聴覚それぞれのフィルタと緊急度を取得できる。
+#[derive(Debug, Clone, PartialEq)]
+pub struct Experience {
+    /// 安定した識別子（i18n キー等に使う英語 ID）
+    pub id: &'static str,
+    /// 視覚側フィルタ（視覚要素が無い体験では `None`）
+    pub vision: Option<Filter>,
+    /// 聴覚側フィルタ（聴覚要素が無い体験では `None`）
+    pub hearing: Option<HearingFilter>,
+    /// 受診喚起の緊急度
+    pub urgency: Urgency,
+}
+
+impl Experience {
+    /// メニエール病: 回転性めまい（視覚）＋ 低音域難聴・低い唸る耳鳴り（聴覚）の三徴候。
+    /// ⚠️ 早期受診が望ましい。
+    pub const MENIERE: Experience = Experience {
+        id: "meniere",
+        vision: Some(Filter::Vertigo),
+        hearing: Some(HearingFilter::Meniere),
+        urgency: Urgency::EarlyConsultation,
+    };
+
+    /// 視覚側フィルタを画像に適用する。視覚要素が無い体験では `Ok(None)`。
+    pub fn apply_vision(
+        &self,
+        img: image::DynamicImage,
+        strength: f32,
+    ) -> Result<Option<image::DynamicImage>> {
+        match self.vision {
+            Some(f) => Ok(Some(apply(f, img, strength)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// 聴覚側フィルタを音声バッファに適用する。聴覚要素が無い体験では `Ok(None)`。
+    pub fn apply_audio(
+        &self,
+        buf: hearing::AudioBuffer,
+        strength: f32,
+    ) -> Result<Option<hearing::AudioBuffer>> {
+        match self.hearing.clone() {
+            Some(f) => Ok(Some(apply_hearing(f, buf, strength)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hearing::AudioBuffer;
+    use image::{DynamicImage, RgbImage};
+
+    fn test_image() -> DynamicImage {
+        DynamicImage::ImageRgb8(RgbImage::from_fn(16, 16, |x, y| {
+            image::Rgb([(x * 8) as u8, (y * 8) as u8, 128])
+        }))
+    }
+
+    fn test_audio() -> AudioBuffer {
+        AudioBuffer { samples: vec![0.1; 2000], sample_rate: 44100, channels: 1 }
+    }
+
+    #[test]
+    fn experience_meniere_canonical_pairing() {
+        let e = Experience::MENIERE;
+        assert_eq!(e.id, "meniere");
+        assert_eq!(e.vision, Some(Filter::Vertigo));
+        assert_eq!(e.hearing, Some(HearingFilter::Meniere));
+        assert_eq!(e.urgency, Urgency::EarlyConsultation);
+    }
+
+    #[test]
+    fn experience_meniere_applies_both_modalities() {
+        let e = Experience::MENIERE;
+        let img = e.apply_vision(test_image(), 0.8).unwrap();
+        assert!(img.is_some(), "MENIERE has a vision component");
+        let audio = e.apply_audio(test_audio(), 0.8).unwrap();
+        assert!(audio.is_some(), "MENIERE has a hearing component");
+    }
+
+    #[test]
+    fn experience_missing_modality_returns_none() {
+        // 聴覚のみ / 視覚のみの体験では欠けている側が None を返すことを確認する。
+        let vision_only = Experience {
+            id: "vision_only",
+            vision: Some(Filter::Cataract),
+            hearing: None,
+            urgency: Urgency::None,
+        };
+        assert!(vision_only.apply_audio(test_audio(), 1.0).unwrap().is_none());
+        assert!(vision_only.apply_vision(test_image(), 1.0).unwrap().is_some());
+
+        let hearing_only = Experience {
+            id: "hearing_only",
+            vision: None,
+            hearing: Some(HearingFilter::Tinnitus { freq_hz: 4000.0 }),
+            urgency: Urgency::None,
+        };
+        assert!(hearing_only.apply_vision(test_image(), 1.0).unwrap().is_none());
+        assert!(hearing_only.apply_audio(test_audio(), 1.0).unwrap().is_some());
+    }
 }


### PR DESCRIPTION
## 概要
P1 移植漏れ #103 を解消。仕様はメニエール病を「難聴＋耳鳴り＋激しいめまい… 視覚（画面回転）と聴覚の複合」と明示していたが、フィルタ自体が存在しなかった。

## 設計判断（複合の表現）
sensus は pure・別バッファ（画像 / 音声）アーキテクチャで、単一バッファに視覚+聴覚の複合症状を持てない。そこで **core に `Experience` 複合記述子**を追加し、「どの視覚フィルタ × どの聴覚フィルタ」を組にすれば仕様どおりかをライブラリ側で正準化。consumer（universal-experience GUI）が三徴候の組み合わせをハードコードせず取得できる。

## 変更
- `hearing::meniere()` + `HearingFilter::Meniere`: 聴覚側合成。**低音域**感音難聴（メニエールの特徴。高音カットの `hearing_loss` とは逆向き）+ ~200 Hz の低い唸る耳鳴り。
- `Experience { id, vision, hearing, urgency }` + `Experience::MENIERE`（Vertigo + Meniere + EarlyConsultation）。`apply_vision()` / `apply_audio()`。
- `Urgency { None, EarlyConsultation, Emergency }`: 局所化文字列を core に埋めない緊急度分類（i18n は consumer 側）。

## テスト（core 265→273）
- meniere: strength=0 恒等 / 空 / ステレオ保持 / 無音→唸り追加 / **低音(60Hz)が高音(2kHz)より強く減衰**
- Experience: MENIERE 正準ペア / 両 modality 適用 / 欠けた modality は Ok(None)

closes #103