### PR TITLE
feat: #104 前庭性めまいの聴覚側を医学的に正しく移植

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **feat: kako-jun/sensus#104 前庭性めまいの聴覚側を医学的に正しく移植（BPPV/前庭神経炎は聴力温存、迷路炎を追加）**: 監査は「vertigo/BPPV/前庭神経炎は視覚半分のみ配線、聴覚側未移植」と疑ったが、調査の結果 **BPPV と前庭神経炎は定義上 聴力が保たれる**（前庭神経炎で難聴を伴えばそれは迷路炎）。難聴・耳鳴りを捏造せず、医学的に正しい配線にした。
+  - `Experience::BPPV`（BppvRotation + `hearing: None` + 緊急性なし）/ `Experience::VESTIBULAR_NEURITIS`（VestibularNeuritis + `hearing: None` + Emergency〔脳卒中鑑別〕）: 聴力温存を doc で明記。
+  - `Experience::LABYRINTHITIS` + `HearingFilter::Labyrinthitis` + `hearing::labyrinthitis()`: 「めまい＋難聴＋耳鳴り」の前庭性複合を医学的に正しく表せる迷路炎を追加。内耳（蝸牛含む）炎症で**高音域感音難聴 + 高音(4 kHz)耳鳴り**。前庭神経炎との鑑別点（聴覚症状の有無）を体験で示す。高音が低音より強く減衰（メニエールの低音減衰と逆向き）を効果アサート。
 - **feat: kako-jun/sensus#103 メニエール病フィルタ + `Experience` 複合記述子を追加**: 仕様の三徴候「回転性めまい + 低音域難聴 + 低い唸る耳鳴り」のうち、フィルタ自体が存在しなかった移植漏れを解消。
   - `hearing::meniere()` + `HearingFilter::Meniere`: 聴覚側を合成。**低音域**感音難聴（メニエールの特徴。加齢性 = 高音カットの `hearing_loss` とは逆向き。100→800 Hz ハイパスの部分ブレンド）+ ~200 Hz の低い唸る耳鳴り。低音(60 Hz)が高音(2 kHz)より強く減衰することを効果アサート（`meniere_attenuates_low_more_than_high`）。
   - `Experience { id, vision: Option<Filter>, hearing: Option<HearingFilter>, urgency: Urgency }`: 視覚と聴覚にまたがる複合体験の正準記述子。sensus は pure・別バッファ（画像/音声）アーキテクチャで単一バッファに複合症状を持てないため、「どの視覚フィルタとどの聴覚フィルタを組にすれば仕様どおりか」をライブラリ側で正準化し、consumer（universal-experience GUI 等）が組み合わせをハードコードせず取得できるようにした。`Experience::MENIERE`（Vertigo + Meniere + 早期受診）。`apply_vision()` / `apply_audio()` は欠けた modality で `Ok(None)`。

--- a/crates/core/src/hearing.rs
+++ b/crates/core/src/hearing.rs
@@ -682,6 +682,26 @@ pub fn meniere(buf: AudioBuffer, strength: f32) -> AudioBuffer {
     tinnitus(stage1, s, 200.0)
 }
 
+/// 迷路炎（labyrinthitis）の聴覚側シミュレーション。
+///
+/// 前庭神経炎（[`crate::Experience::VESTIBULAR_NEURITIS`]）が前庭神経のみの炎症で
+/// **聴力は保たれる**のに対し、迷路炎は内耳（蝸牛を含む）の炎症で、回転性めまいに
+/// **感音難聴と耳鳴りを伴う**。この聴覚症状の有無が両者の臨床的鑑別点であり、
+/// 「めまいの聴覚側複合」を医学的に正しく表せるのは迷路炎（やメニエール病）の側。
+///
+/// 1. 感音難聴: 高音域カット（[`hearing_loss`] と同系の広めの感音難聴を近似）
+/// 2. 高音の耳鳴り: ~4 kHz（メニエールの低い唸りとは音色が異なる）
+///
+/// `strength = 0.0` は元音声と同一。
+pub fn labyrinthitis(buf: AudioBuffer, strength: f32) -> AudioBuffer {
+    let s = strength.clamp(0.0, 1.0);
+    if s == 0.0 {
+        return buf;
+    }
+    let stage1 = hearing_loss(buf, s);
+    tinnitus(stage1, s, 4000.0)
+}
+
 // ---------------------------------------------------------------
 // テスト
 // ---------------------------------------------------------------
@@ -1022,6 +1042,56 @@ mod tests {
         let out_rms = rms(&out.samples);
         let rel_diff = (out_rms - orig_rms).abs() / orig_rms.max(1e-6);
         assert!(rel_diff > 0.05, "misophonia strength=1 must alter the trigger-band signal (rel_diff={rel_diff})");
+    }
+
+    // ---------------------------------------------------------------
+    // Issue #104: labyrinthitis（前庭性めまいの聴覚側複合）
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn labyrinthitis_strength_zero_is_identity() {
+        let buf = sine_wave(440.0, 1000, 44100);
+        let orig = buf.samples.clone();
+        let out = labyrinthitis(buf, 0.0);
+        assert_eq!(out.samples, orig, "labyrinthitis strength=0 should be byte-exact identity");
+    }
+
+    #[test]
+    fn labyrinthitis_empty_buffer_does_not_panic() {
+        let buf = AudioBuffer { samples: vec![], sample_rate: 44100, channels: 1 };
+        let out = labyrinthitis(buf, 1.0);
+        assert!(out.samples.is_empty());
+    }
+
+    #[test]
+    fn labyrinthitis_stereo_preserves_channel_count() {
+        let buf = AudioBuffer { samples: vec![0.1; 2000], sample_rate: 44100, channels: 2 };
+        let out = labyrinthitis(buf, 1.0);
+        assert_eq!(out.channels, 2);
+        assert_eq!(out.samples.len(), 2000);
+    }
+
+    #[test]
+    fn labyrinthitis_adds_tinnitus_to_silence() {
+        let buf = silence(44100, 44100, 1);
+        let out = labyrinthitis(buf, 1.0);
+        assert!(rms(&out.samples) > 0.0, "labyrinthitis should add tinnitus to silence");
+    }
+
+    #[test]
+    fn labyrinthitis_attenuates_high_more_than_low() {
+        // 感音難聴は高音域カット: 高音(8 kHz)は低音(200 Hz)より強く減衰する。
+        // メニエール（低音側が落ちる）とは逆向きであることを検証する。
+        let high = sine_wave(8000.0, 44100, 44100);
+        let high_ratio = rms(&labyrinthitis(high.clone(), 1.0).samples) / rms(&high.samples).max(1e-6);
+
+        let low = sine_wave(200.0, 44100, 44100);
+        let low_ratio = rms(&labyrinthitis(low.clone(), 1.0).samples) / rms(&low.samples).max(1e-6);
+
+        assert!(
+            high_ratio < low_ratio,
+            "labyrinthitis must attenuate high freq more than low: high_ratio={high_ratio}, low_ratio={low_ratio}"
+        );
     }
 
     // ---------------------------------------------------------------

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -169,6 +169,10 @@ pub enum HearingFilter {
     /// メニエール病の聴覚側: 低音域難聴 + 低い唸る耳鳴り（複合）。
     /// 回転性めまい（視覚）と組で [`Experience::MENIERE`] として正準化される。
     Meniere,
+    /// 迷路炎の聴覚側: 高音域感音難聴 + 高音の耳鳴り（複合）。
+    /// 回転性めまい（視覚）と組で [`Experience::LABYRINTHITIS`] として正準化される。
+    /// 前庭神経炎（聴力温存）との鑑別点となる聴覚症状を表す。
+    Labyrinthitis,
 }
 
 /// 聴覚フィルタを音声バッファに適用する。
@@ -201,6 +205,7 @@ pub fn apply_hearing(
             hearing::auditory_processing_disorder(buf, strength)
         }
         HearingFilter::Meniere => hearing::meniere(buf, strength),
+        HearingFilter::Labyrinthitis => hearing::labyrinthitis(buf, strength),
     };
     Ok(out)
 }
@@ -245,6 +250,41 @@ impl Experience {
         id: "meniere",
         vision: Some(Filter::Vertigo),
         hearing: Some(HearingFilter::Meniere),
+        urgency: Urgency::EarlyConsultation,
+    };
+
+    /// 良性発作性頭位めまい症（BPPV）: 頭位変化で生じる回転性めまい。
+    ///
+    /// **聴覚症状は無い**（耳石が三半規管に入り込む純粋な前庭性めまいで、蝸牛＝聴覚は
+    /// 障害されない）。したがって `hearing: None` が医学的に正しい。良性で緊急性も低い。
+    pub const BPPV: Experience = Experience {
+        id: "bppv",
+        vision: Some(Filter::BppvRotation),
+        hearing: None,
+        urgency: Urgency::None,
+    };
+
+    /// 前庭神経炎（vestibular neuritis）: 突然の激しい回転性めまい。
+    ///
+    /// 前庭神経のみの炎症で**聴力は保たれる**（難聴・耳鳴りを伴えばそれは迷路炎＝
+    /// [`Experience::LABYRINTHITIS`]）。この聴覚温存が両者の鑑別点なので `hearing: None`。
+    /// 突然発症のめまいは脳卒中との鑑別が必要なため緊急。
+    pub const VESTIBULAR_NEURITIS: Experience = Experience {
+        id: "vestibular_neuritis",
+        vision: Some(Filter::VestibularNeuritis),
+        hearing: None,
+        urgency: Urgency::Emergency,
+    };
+
+    /// 迷路炎（labyrinthitis）: 回転性めまい（視覚）＋ 高音域感音難聴・高音の耳鳴り（聴覚）。
+    ///
+    /// 内耳（蝸牛を含む）の炎症で、前庭神経炎と違い**聴覚症状を伴う**。
+    /// 「めまいの聴覚側複合」を医学的に正しく表せる前庭性疾患（メニエール病と並ぶ）。
+    /// 突発的な感音難聴は早期治療が予後を左右するため早期受診が望ましい。
+    pub const LABYRINTHITIS: Experience = Experience {
+        id: "labyrinthitis",
+        vision: Some(Filter::Vertigo),
+        hearing: Some(HearingFilter::Labyrinthitis),
         urgency: Urgency::EarlyConsultation,
     };
 
@@ -296,6 +336,29 @@ mod tests {
         assert_eq!(e.vision, Some(Filter::Vertigo));
         assert_eq!(e.hearing, Some(HearingFilter::Meniere));
         assert_eq!(e.urgency, Urgency::EarlyConsultation);
+    }
+
+    #[test]
+    fn experience_vestibular_pairings_are_medically_correct() {
+        // BPPV と前庭神経炎は聴力温存 = hearing None。迷路炎のみ聴覚を伴う。
+        assert_eq!(Experience::BPPV.vision, Some(Filter::BppvRotation));
+        assert_eq!(Experience::BPPV.hearing, None);
+        assert_eq!(Experience::BPPV.urgency, Urgency::None);
+
+        assert_eq!(Experience::VESTIBULAR_NEURITIS.vision, Some(Filter::VestibularNeuritis));
+        assert_eq!(Experience::VESTIBULAR_NEURITIS.hearing, None);
+        assert_eq!(Experience::VESTIBULAR_NEURITIS.urgency, Urgency::Emergency);
+
+        assert_eq!(Experience::LABYRINTHITIS.hearing, Some(HearingFilter::Labyrinthitis));
+        assert!(Experience::LABYRINTHITIS.vision.is_some());
+    }
+
+    #[test]
+    fn experience_vision_only_returns_none_audio() {
+        // BPPV は視覚のみ → 音声適用は Ok(None)
+        let bppv = Experience::BPPV;
+        assert!(bppv.apply_audio(test_audio(), 1.0).unwrap().is_none());
+        assert!(bppv.apply_vision(test_image(), 1.0).unwrap().is_some());
     }
 
     #[test]


### PR DESCRIPTION
## 概要
P1 #104。監査は「vertigo/BPPV/前庭神経炎は視覚半分のみ配線、聴覚側未移植」と疑った。調査の結果、**前提が一部医学的に不正確**だった。

## 医学的事実（誠実化）
- **BPPV**: 耳石が三半規管に入り込む純粋な前庭性めまい。蝸牛＝**聴覚は障害されない**。
- **前庭神経炎**: 前庭神経のみの炎症で**聴力は保たれる**。難聴を伴えばそれは別疾患＝迷路炎。この聴覚温存が両者の鑑別点。
- 「めまい＋難聴＋耳鳴り」の前庭性複合に該当するのは**迷路炎（labyrinthitis）**（内耳＝蝸牛含む の炎症）。

難聴・耳鳴りを捏造するのではなく、医学的に正しい配線にした（tail-match の「implemented 詐称」是正と同じ誠実化の精神）。

## 変更
- `Experience::BPPV`（BppvRotation + hearing None + 緊急性なし）
- `Experience::VESTIBULAR_NEURITIS`（VestibularNeuritis + hearing None + Emergency〔脳卒中鑑別〕）
- `Experience::LABYRINTHITIS` + `HearingFilter::Labyrinthitis` + `hearing::labyrinthitis()`: 高音域感音難聴 + 高音(4kHz)耳鳴り。前庭神経炎との鑑別点を体験で示す。

## テスト（core 273→280）
- labyrinthitis: strength=0 恒等 / 空 / ステレオ / 無音→耳鳴り / **高音(8kHz)が低音(200Hz)より強く減衰**（メニエールと逆向き）
- Experience: BPPV/VN は hearing None・迷路炎は Labyrinthitis、視覚のみ体験で apply_audio が Ok(None)

closes #104