### PR TITLE
feat: #105 聴覚フィルタ + AudioPipeline を CLI から利用可能に（--audio / WAV）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **feat: kako-jun/sensus#105 聴覚フィルタ + AudioPipeline を CLI から利用可能に（`--audio` / WAV）**: 聴覚モジュール全体（15 フィルタ）と `AudioPipeline` が CLI から一切叩けず、Cargo.toml の description が "hearing loss" を宣伝しながら binary では到達不可だった矛盾を解消。
+  - `--audio <in.wav> --hearing <filter>... -o <out.wav>`: WAV を読み、`--hearing` の聴覚フィルタを `AudioPipeline` で順に適用して WAV 出力。`--hearing` は複数指定でチェーン可。パラメータ付きフィルタ用に `--freq`（tinnitus/sudden-hearing-loss/misophonia）と `--semitones`（pitch-shift）を追加。
+  - WAV I/O は `hound` で実装（`crates/cli/src/audio.rs`）。整数/浮動小数 PCM を正規化 f32 で読み、出力時に入力の bit 深度・形式へ戻す。チャンネル数は適用後バッファに追従（diplacusis の mono→stereo を保つ）。**mp3/flac 等の広域デコードは非対象**。
+  - `--audio` は `--input`/`--filter`/`--pipe`/`--mpo`/`--portrait` と排他。`--hearing` 無し・`-o` 無しは明示エラー。
+  - 統合テスト `crates/cli/tests/audio_integration.rs` 5 件（hearing-loss が 8 kHz を減衰 / チェーン / --hearing 無しで失敗 / diplacusis mono→stereo / --filter 併用で失敗）。README の CLI usage・フラグ表・hearing/Experience セクションを更新。
 - **feat: kako-jun/sensus#104 前庭性めまいの聴覚側を医学的に正しく移植（BPPV/前庭神経炎は聴力温存、迷路炎を追加）**: 監査は「vertigo/BPPV/前庭神経炎は視覚半分のみ配線、聴覚側未移植」と疑ったが、調査の結果 **BPPV と前庭神経炎は定義上 聴力が保たれる**（前庭神経炎で難聴を伴えばそれは迷路炎）。難聴・耳鳴りを捏造せず、医学的に正しい配線にした。
   - `Experience::BPPV`（BppvRotation + `hearing: None` + 緊急性なし）/ `Experience::VESTIBULAR_NEURITIS`（VestibularNeuritis + `hearing: None` + Emergency〔脳卒中鑑別〕）: 聴力温存を doc で明記。
   - `Experience::LABYRINTHITIS` + `HearingFilter::Labyrinthitis` + `hearing::labyrinthitis()`: 「めまい＋難聴＋耳鳴り」の前庭性複合を医学的に正しく表せる迷路炎を追加。内耳（蝸牛含む）炎症で**高音域感音難聴 + 高音(4 kHz)耳鳴り**。前庭神経炎との鑑別点（聴覚症状の有無）を体験で示す。高音が低音より強く減衰（メニエールの低音減衰と逆向き）を効果アサート。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1083,7 @@ name = "sensus"
 version = "0.4.0"
 dependencies = [
  "clap",
+ "hound",
  "image",
  "sensus-core",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ accessibility demos, educational tools, and apps like
 **v0.4.0** — stable release on [crates.io](https://crates.io/crates/sensus).
 All vision filters through Phase 4 (color vision, refraction, visual field,
 light/transparency, balance/vertigo, eye fatigue, and more) are implemented,
-plus 11 hearing-loss filters in the library. See
+plus 15 hearing filters (usable from the CLI via `--audio`). See
 [`docs/roadmap.md`](docs/roadmap.md) for the full phase tracker.
 
 ## Filters
@@ -56,18 +56,28 @@ Depth-aware refraction is also available **CLI-side only** via
 `--filter myopia-depth` / `hyperopia-depth` / `depth-of-field` combined with
 `--depth`, `--mpo`, or `--portrait` (#19).
 
-### Hearing (library API)
+### Hearing (library + CLI)
 
-11 hearing filters operate on audio buffers (#7–#9): `hearing_loss`,
+15 hearing filters operate on audio buffers (#7–#9, #102–#104): `hearing_loss`,
 `sudden_hearing_loss`, `noise_induced_hearing_loss`, `tinnitus`,
-`hyperacusis`, `paracusis`, `amusia`, `dysmelodia`, `pitch_shift_semitones`,
-`diplacusis`, and `auditory_processing_disorder` (APD). Each takes a
+`hyperacusis`, `misophonia`, `paracusis`, `amusia`, `dysmelodia`,
+`pitch_shift_semitones`, `diplacusis`, `auditory_processing_disorder` (APD),
+`meniere`, and `labyrinthitis`. Each takes a
 `sensus_core::hearing::AudioBuffer` (f32 interleaved PCM) and returns one.
 
-> **Note:** hearing filters are **library-only** — the `sensus` CLI has no
-> audio I/O and its `--filter` flag accepts vision filters only. Use
-> `sensus_core::apply_hearing` / `HearingFilter` from Rust. CLI support for
-> hearing is tracked in #105.
+From the CLI, use `--audio <in.wav> --hearing <filter> -o <out.wav>` (WAV only).
+See [CLI usage](#cli-usage). From Rust, use `sensus_core::apply_hearing` /
+`HearingFilter`, or chain via `AudioPipeline`.
+
+### Composite experiences (`Experience`)
+
+Some conditions span both vision and hearing (e.g. Ménière's disease =
+spinning vertigo + low-frequency hearing loss + low-pitched tinnitus). Because
+sensus is a pure, separate-buffer (image vs audio) library, `Experience`
+canonicalises which vision filter pairs with which hearing filter, so consumers
+(e.g. the universal-experience GUI) don't hard-code the combination:
+`Experience::MENIERE`, `BPPV`, `VESTIBULAR_NEURITIS`, `LABYRINTHITIS`. Each
+carries an `Urgency` classification for "see a doctor" prompts.
 
 Each filter ships with a short note on **when to see a doctor** — sensus is
 designed both as an empathy / education tool and as an early-warning primer
@@ -110,6 +120,13 @@ sensus -i photo.png -o out.png --filter glaucoma --filter cataract --strength 0.
 ffmpeg -i video.mp4 -f image2pipe -vcodec mjpeg - | \
     sensus --filter deuteranopia --pipe | \
     ffmpeg -f mjpeg -i - -c:v libx264 out.mp4
+
+# Hearing: apply hearing filters to a WAV file (#105). WAV in / WAV out only.
+sensus --audio voice.wav -o voice-hearing-loss.wav --hearing hearing-loss -s 1.0
+sensus --audio voice.wav -o voice-tinnitus.wav     --hearing tinnitus     --freq 6000 -s 0.7
+# Chain hearing filters and use the composite Ménière hearing side
+sensus --audio voice.wav -o voice-meniere.wav      --hearing meniere      -s 0.8
+sensus --audio voice.wav -o voice-chain.wav        --hearing hearing-loss tinnitus --freq 4000
 ```
 
 Flags:
@@ -117,8 +134,12 @@ Flags:
 | Flag | Description |
 |---|---|
 | `-i`, `--input`    | Input image path (PNG / JPEG / WebP, etc.). |
-| `-o`, `--output`   | Output image path. Format is inferred from the extension. |
-| `-f`, `--filter`   | Filter to apply (e.g. `deuteranopia`, `cataract`, `glaucoma`). |
+| `-o`, `--output`   | Output path (image, or WAV with `--audio`). Format is inferred from the extension. |
+| `-f`, `--filter`   | Vision filter to apply (e.g. `deuteranopia`, `cataract`, `glaucoma`). |
+| `--audio`          | Input audio path (WAV). Routes to hearing-filter mode; requires `--hearing` and `-o`. Cannot be combined with `--filter` / `--pipe`. |
+| `--hearing`        | Hearing filter(s) for `--audio` (e.g. `hearing-loss`, `tinnitus`, `meniere`, `labyrinthitis`). Repeatable to chain. |
+| `--freq`           | Frequency (Hz) for `--hearing tinnitus` / `sudden-hearing-loss` / `misophonia`. Default `4000`. |
+| `--semitones`      | Semitones for `--hearing pitch-shift` (negative = lower). Default `0.0`. |
 | `-s`, `--strength` | Strength `0.0 – 1.0`. `0.0` keeps the original; `1.0` is full effect. Default `1.0`. |
 | `--axis`           | Astigmatism cylinder axis in degrees `0.0 – 180.0`. Only used with `--filter astigmatism`. Default `90.0` (with-the-rule: vertical lines sharp, horizontal blurred). |
 
@@ -171,12 +192,12 @@ cylindrical lens / line spread function), not an elliptical disk — see
 The same function signatures can be applied frame-by-frame for video, or
 chained together via `sensus_core::pipeline`.
 
-### Hearing filters (library only)
+### Hearing filters
 
 Hearing filters live in `sensus_core::hearing` and are dispatched via
-`apply_hearing`. They operate on audio buffers, not images, and are **not
-exposed through the CLI** (see the note in the Filters section; CLI support
-is tracked in #105).
+`apply_hearing`. They operate on audio buffers, not images. From the CLI they
+are reachable via `--audio <in.wav> --hearing <filter> -o <out.wav>` (WAV only);
+from Rust use the API below or chain them via `AudioPipeline`.
 
 ```rust
 use sensus_core::{apply_hearing, hearing::AudioBuffer, HearingFilter};

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,7 +23,10 @@ sensus-core = { workspace = true }
 clap = { workspace = true }
 image = { workspace = true, default-features = true }
 thiserror = { workspace = true }
+# WAV 入出力のみ（#105）。mp3/flac 等は対象外。
+hound = "3"
 
 [dev-dependencies]
 image = { workspace = true, default-features = true }
 tempfile = { workspace = true }
+hound = "3"

--- a/crates/cli/src/audio.rs
+++ b/crates/cli/src/audio.rs
@@ -1,0 +1,86 @@
+//! WAV 音声の入出力（#105）。
+//!
+//! sensus-core は I/O を持たない pure ライブラリなので、CLI 側で WAV ↔ [`AudioBuffer`]
+//! の変換を担う。対象は WAV のみ（mp3/flac/ogg 等の広域デコードは非対象）。
+//!
+//! サンプルは内部的に正規化 f32（-1.0..=1.0）で扱い、出力時に入力の bit 深度・
+//! サンプル形式（整数 / 浮動小数）へ戻す。チャンネル数・サンプルレートは
+//! フィルタ適用後のバッファ（diplacusis 等で mono→stereo になりうる）に追従させる。
+
+use std::path::Path;
+
+use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
+use sensus_core::hearing::AudioBuffer;
+
+/// WAV ファイルを読み、正規化 f32 の [`AudioBuffer`] と元の [`WavSpec`] を返す。
+///
+/// 元 spec は出力時に bit 深度・サンプル形式を保つために返す。
+pub fn read_wav(path: &Path) -> Result<(AudioBuffer, WavSpec), String> {
+    let reader =
+        WavReader::open(path).map_err(|e| format!("failed to open WAV {path:?}: {e}"))?;
+    let spec = reader.spec();
+
+    let samples: Vec<f32> = match spec.sample_format {
+        SampleFormat::Float => reader
+            .into_samples::<f32>()
+            .collect::<Result<_, _>>()
+            .map_err(|e| format!("failed to read float WAV samples: {e}"))?,
+        SampleFormat::Int => {
+            // i{bits} → f32 正規化。フルスケールは 2^(bits-1)。
+            let scale = (1i64 << (spec.bits_per_sample.saturating_sub(1))) as f32;
+            reader
+                .into_samples::<i32>()
+                .map(|s| s.map(|v| v as f32 / scale))
+                .collect::<Result<_, _>>()
+                .map_err(|e| format!("failed to read integer WAV samples: {e}"))?
+        }
+    };
+
+    Ok((
+        AudioBuffer {
+            samples,
+            sample_rate: spec.sample_rate,
+            channels: spec.channels,
+        },
+        spec,
+    ))
+}
+
+/// [`AudioBuffer`] を WAV ファイルに書く。
+///
+/// bit 深度・サンプル形式は `src_spec`（入力 WAV の spec）を踏襲するが、
+/// チャンネル数・サンプルレートは `buf` 側に追従させる。
+pub fn write_wav(path: &Path, buf: &AudioBuffer, src_spec: WavSpec) -> Result<(), String> {
+    let out_spec = WavSpec {
+        channels: buf.channels,
+        sample_rate: buf.sample_rate,
+        bits_per_sample: src_spec.bits_per_sample,
+        sample_format: src_spec.sample_format,
+    };
+    let mut writer =
+        WavWriter::create(path, out_spec).map_err(|e| format!("failed to create WAV {path:?}: {e}"))?;
+
+    match src_spec.sample_format {
+        SampleFormat::Float => {
+            for &s in &buf.samples {
+                writer
+                    .write_sample(s)
+                    .map_err(|e| format!("failed to write float WAV sample: {e}"))?;
+            }
+        }
+        SampleFormat::Int => {
+            // フルスケール - 1 にスケール（+1.0 が範囲外にならないようにする）。
+            let max = (1i64 << (src_spec.bits_per_sample.saturating_sub(1))) as f32 - 1.0;
+            for &s in &buf.samples {
+                let v = (s.clamp(-1.0, 1.0) * max).round() as i32;
+                writer
+                    .write_sample(v)
+                    .map_err(|e| format!("failed to write integer WAV sample: {e}"))?;
+            }
+        }
+    }
+
+    writer
+        .finalize()
+        .map_err(|e| format!("failed to finalize WAV {path:?}: {e}"))
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,12 +3,14 @@
 //! Phase 1 (Issue #2) 以降で各フィルタを実装する。本 scaffold (#1) では
 //! 引数を受け取り、未実装フィルタの場合は stderr に通知して exit(2) する。
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::{Parser, ValueEnum};
-use sensus_core::{pipeline::{FilterStep, Pipeline}, stereo::{split_mpo, stereo_to_depth, read_xmp_depth}, vision::{depth_aware_blur, DepthBlurKind}, Error as CoreError, Filter as CoreFilter};
+use sensus_core::{pipeline::{FilterStep, Pipeline}, stereo::{split_mpo, stereo_to_depth, read_xmp_depth}, vision::{depth_aware_blur, DepthBlurKind}, AudioPipeline, Error as CoreError, Filter as CoreFilter, HearingFilter};
 use thiserror::Error;
+
+mod audio;
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum Filter {
@@ -97,6 +99,65 @@ impl Filter {
                 // depth フィルタは pipeline を通さないため、ここには来ない
                 unreachable!("depth filters must be handled separately")
             }
+        }
+    }
+}
+
+/// CLI-facing hearing filter enum (clap derive). Maps to core [`HearingFilter`].
+/// `--audio` モードで `--hearing` に指定する（#105）。
+//
+// `HearingLoss` は疾患名（難聴）であって enum 名の重複ではないため allow する。
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Hearing {
+    /// 難聴（高音域カット）
+    HearingLoss,
+    /// 突発性難聴（--freq の帯域を削る）
+    SuddenHearingLoss,
+    /// 騒音性難聴（4 kHz 付近の損失）
+    NoiseInducedHearingLoss,
+    /// 耳鳴り（--freq の正弦波を常時ミックス）
+    Tinnitus,
+    /// 音響過敏（全体を異常増幅）
+    Hyperacusis,
+    /// ミソフォニア（--freq 中心のトリガー帯域だけ過剰増幅 + 歪み）
+    Misophonia,
+    /// 変音（金属的な歪み）
+    Paracusis,
+    /// 音楽音痴（音程差を識別しにくくする）
+    Amusia,
+    /// ジスメロディア（不快・歪んだ音）
+    Dysmelodia,
+    /// 音程シフト（--semitones 半音）
+    PitchShift,
+    /// ダイプラクシス（左右耳で異なる音程）
+    Diplacusis,
+    /// APD（聴覚情報処理障害）
+    AuditoryProcessingDisorder,
+    /// メニエール病の聴覚側（低音域難聴 + 低い唸る耳鳴り）
+    Meniere,
+    /// 迷路炎の聴覚側（高音域感音難聴 + 高音の耳鳴り）
+    Labyrinthitis,
+}
+
+impl Hearing {
+    /// Map the CLI-facing enum to the core enum, pulling parameters from `cli`.
+    fn to_core(self, cli: &Cli) -> HearingFilter {
+        match self {
+            Hearing::HearingLoss => HearingFilter::HearingLoss,
+            Hearing::SuddenHearingLoss => HearingFilter::SuddenHearingLoss { freq_hz: cli.freq },
+            Hearing::NoiseInducedHearingLoss => HearingFilter::NoiseInducedHearingLoss,
+            Hearing::Tinnitus => HearingFilter::Tinnitus { freq_hz: cli.freq },
+            Hearing::Hyperacusis => HearingFilter::Hyperacusis,
+            Hearing::Misophonia => HearingFilter::Misophonia { freq_hz: cli.freq },
+            Hearing::Paracusis => HearingFilter::Paracusis,
+            Hearing::Amusia => HearingFilter::Amusia,
+            Hearing::Dysmelodia => HearingFilter::Dysmelodia,
+            Hearing::PitchShift => HearingFilter::PitchShift { semitones: cli.semitones },
+            Hearing::Diplacusis => HearingFilter::Diplacusis,
+            Hearing::AuditoryProcessingDisorder => HearingFilter::AuditoryProcessingDisorder,
+            Hearing::Meniere => HearingFilter::Meniere,
+            Hearing::Labyrinthitis => HearingFilter::Labyrinthitis,
         }
     }
 }
@@ -203,6 +264,23 @@ struct Cli {
     /// Cannot be combined with --input.
     #[arg(long, conflicts_with = "input")]
     pipe: bool,
+
+    /// Input audio path (WAV). Routes to hearing-filter mode; requires --hearing and --output.
+    /// Cannot be combined with image filters (--filter) or --pipe.
+    #[arg(long, conflicts_with_all = ["input", "pipe", "mpo", "portrait"])]
+    audio: Option<PathBuf>,
+
+    /// Hearing filter(s) to apply to --audio. Specify multiple times to chain.
+    #[arg(long, value_enum, num_args = 1..)]
+    hearing: Vec<Hearing>,
+
+    /// Frequency (Hz) for --hearing tinnitus / sudden-hearing-loss / misophonia. Default: 4000.
+    #[arg(long, default_value_t = 4000.0, value_parser = parse_freq)]
+    freq: f32,
+
+    /// Semitones for --hearing pitch-shift (negative = lower, positive = higher). Default: 0.0
+    #[arg(long, default_value_t = 0.0, value_parser = parse_semitones)]
+    semitones: f32,
 }
 
 /// Parse the `--strength` argument and reject values outside `0.0..=1.0`
@@ -259,6 +337,28 @@ fn parse_axis(s: &str) -> Result<f32, String> {
         .map_err(|e: std::num::ParseFloatError| e.to_string())?;
     if v.is_nan() || !(0.0..=180.0).contains(&v) {
         return Err(format!("axis must be in 0.0..=180.0 degrees, got {v}"));
+    }
+    Ok(v)
+}
+
+/// Parse `--freq` (Hz) for hearing filters. 正の有限値 0 < f <= 20000 のみ許容する。
+fn parse_freq(s: &str) -> Result<f32, String> {
+    let v: f32 = s
+        .parse()
+        .map_err(|e: std::num::ParseFloatError| e.to_string())?;
+    if !v.is_finite() || v <= 0.0 || v > 20000.0 {
+        return Err(format!("freq must be in 0.0 (exclusive)..=20000.0 Hz, got {v}"));
+    }
+    Ok(v)
+}
+
+/// Parse `--semitones` for pitch-shift. 有限値かつ ±48 半音（±4 オクターブ）以内。
+fn parse_semitones(s: &str) -> Result<f32, String> {
+    let v: f32 = s
+        .parse()
+        .map_err(|e: std::num::ParseFloatError| e.to_string())?;
+    if !v.is_finite() || !(-48.0..=48.0).contains(&v) {
+        return Err(format!("semitones must be finite and in -48.0..=48.0, got {v}"));
     }
     Ok(v)
 }
@@ -324,6 +424,10 @@ enum RunError {
     #[error("{0}")]
     InputRequired(String),
 
+    /// --audio モードのバリデーション失敗 / WAV 読み書き失敗
+    #[error("{0}")]
+    AudioError(String),
+
     #[error("sensus: I/O error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -356,6 +460,10 @@ fn main() -> ExitCode {
             eprintln!("{msg}");
             ExitCode::FAILURE
         }
+        Err(RunError::AudioError(msg)) => {
+            eprintln!("{msg}");
+            ExitCode::FAILURE
+        }
         Err(RunError::NotImplemented(msg)) => {
             eprintln!("{msg}");
             ExitCode::from(2)
@@ -368,6 +476,11 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: Cli) -> Result<(), RunError> {
+    // --audio モード: WAV を読み、聴覚フィルタチェーンを適用して WAV に書き出す
+    if let Some(audio_path) = cli.audio.clone() {
+        return run_audio(&cli, &audio_path);
+    }
+
     // --pipe モード: stdin から JPEG フレームを読み stdout に出力する
     if cli.pipe {
         return run_pipe(&cli);
@@ -577,6 +690,36 @@ fn run(cli: Cli) -> Result<(), RunError> {
         }),
         Err(e) => Err(RunError::Pipeline(format!("sensus: {e}"))),
     }
+}
+
+/// --audio モード: WAV を読み、`--hearing` の聴覚フィルタを [`AudioPipeline`] で
+/// 順番に適用し、WAV に書き出す。
+fn run_audio(cli: &Cli, audio_path: &Path) -> Result<(), RunError> {
+    if cli.hearing.is_empty() {
+        return Err(RunError::AudioError(
+            "sensus: --audio requires at least one --hearing filter".to_string(),
+        ));
+    }
+    if !cli.filter.is_empty() {
+        return Err(RunError::AudioError(
+            "sensus: --audio (hearing) cannot be combined with --filter (image filters)".to_string(),
+        ));
+    }
+    let out_path = cli.output.as_ref().ok_or_else(|| {
+        RunError::AudioError("sensus: --output <PATH> is required with --audio".to_string())
+    })?;
+
+    let (buf, spec) = audio::read_wav(audio_path).map_err(RunError::AudioError)?;
+
+    let mut pipeline = AudioPipeline::new();
+    for h in &cli.hearing {
+        pipeline = pipeline.push(h.to_core(cli), cli.strength);
+    }
+    let out = pipeline
+        .apply(&buf)
+        .map_err(|e| RunError::AudioError(format!("sensus: {e}")))?;
+
+    audio::write_wav(out_path, &out, spec).map_err(RunError::AudioError)
 }
 
 /// 画像にフィルタパイプラインを適用する（--pipe モードと通常モードの共通処理）。

--- a/crates/cli/tests/audio_integration.rs
+++ b/crates/cli/tests/audio_integration.rs
@@ -1,0 +1,187 @@
+//! Integration tests for --audio (hearing filter) mode (Issue #105).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use hound::{SampleFormat, WavReader, WavSpec, WavWriter};
+
+fn sensus_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sensus"))
+}
+
+/// 16-bit PCM の 440 Hz サイン波 WAV を生成して path に書く。
+fn write_sine_wav(path: &std::path::Path, freq: f32, frames: usize, sample_rate: u32, channels: u16) {
+    let spec = WavSpec {
+        channels,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    let mut writer = WavWriter::create(path, spec).unwrap();
+    for i in 0..frames {
+        let t = i as f32 / sample_rate as f32;
+        let s = (2.0 * std::f32::consts::PI * freq * t).sin();
+        let v = (s * 30000.0) as i16;
+        for _ in 0..channels {
+            writer.write_sample(v).unwrap();
+        }
+    }
+    writer.finalize().unwrap();
+}
+
+fn read_wav_samples(path: &std::path::Path) -> (Vec<f32>, WavSpec) {
+    let reader = WavReader::open(path).unwrap();
+    let spec = reader.spec();
+    let scale = (1i64 << (spec.bits_per_sample - 1)) as f32;
+    let samples: Vec<f32> = match spec.sample_format {
+        SampleFormat::Float => reader.into_samples::<f32>().map(|s| s.unwrap()).collect(),
+        SampleFormat::Int => reader
+            .into_samples::<i32>()
+            .map(|s| s.unwrap() as f32 / scale)
+            .collect(),
+    };
+    (samples, spec)
+}
+
+fn rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    (samples.iter().map(|&x| x * x).sum::<f32>() / samples.len() as f32).sqrt()
+}
+
+#[test]
+fn audio_hearing_loss_produces_wav() {
+    let dir = tempfile::tempdir().unwrap();
+    let in_path = dir.path().join("in.wav");
+    let out_path = dir.path().join("out.wav");
+    // 8 kHz の高音サイン波 → 難聴(高音カット)で大きく減衰するはず
+    write_sine_wav(&in_path, 8000.0, 44100, 44100, 1);
+
+    let status = Command::new(sensus_bin())
+        .args([
+            "--audio",
+            in_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+            "--hearing",
+            "hearing-loss",
+            "-s",
+            "1.0",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "sensus --audio should succeed");
+    assert!(out_path.exists(), "output WAV should be written");
+
+    let (in_samples, _) = read_wav_samples(&in_path);
+    let (out_samples, out_spec) = read_wav_samples(&out_path);
+    assert_eq!(out_spec.sample_rate, 44100);
+    assert_eq!(out_spec.channels, 1);
+    // 高音域カットで RMS が顕著に下がる
+    assert!(
+        rms(&out_samples) < rms(&in_samples) * 0.8,
+        "hearing-loss should attenuate the 8 kHz tone (in_rms={}, out_rms={})",
+        rms(&in_samples),
+        rms(&out_samples)
+    );
+}
+
+#[test]
+fn audio_chains_multiple_hearing_filters() {
+    let dir = tempfile::tempdir().unwrap();
+    let in_path = dir.path().join("in.wav");
+    let out_path = dir.path().join("out.wav");
+    write_sine_wav(&in_path, 440.0, 22050, 44100, 1);
+
+    let status = Command::new(sensus_bin())
+        .args([
+            "--audio",
+            in_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+            "--hearing",
+            "hearing-loss",
+            "tinnitus",
+            "--freq",
+            "4000",
+            "-s",
+            "0.8",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "chained hearing filters should succeed");
+    let (out_samples, _) = read_wav_samples(&out_path);
+    assert!(rms(&out_samples) > 0.0);
+}
+
+#[test]
+fn audio_without_hearing_filter_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let in_path = dir.path().join("in.wav");
+    let out_path = dir.path().join("out.wav");
+    write_sine_wav(&in_path, 440.0, 1000, 44100, 1);
+
+    let output = Command::new(sensus_bin())
+        .args([
+            "--audio",
+            in_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "--audio without --hearing must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--hearing"), "error should mention --hearing: {stderr}");
+}
+
+#[test]
+fn audio_diplacusis_mono_to_stereo() {
+    // diplacusis は mono → stereo に変換する。出力 WAV が 2ch になることを確認。
+    let dir = tempfile::tempdir().unwrap();
+    let in_path = dir.path().join("in.wav");
+    let out_path = dir.path().join("out.wav");
+    write_sine_wav(&in_path, 440.0, 4000, 44100, 1);
+
+    let status = Command::new(sensus_bin())
+        .args([
+            "--audio",
+            in_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+            "--hearing",
+            "diplacusis",
+            "-s",
+            "1.0",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let (_, out_spec) = read_wav_samples(&out_path);
+    assert_eq!(out_spec.channels, 2, "diplacusis output should be stereo");
+}
+
+#[test]
+fn audio_conflicts_with_image_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let in_path = dir.path().join("in.wav");
+    let out_path = dir.path().join("out.wav");
+    write_sine_wav(&in_path, 440.0, 1000, 44100, 1);
+
+    // --audio と --filter(画像) は併用不可（clap の conflicts でも弾かれるが念のため）
+    let output = Command::new(sensus_bin())
+        .args([
+            "--audio",
+            in_path.to_str().unwrap(),
+            "-o",
+            out_path.to_str().unwrap(),
+            "--hearing",
+            "hearing-loss",
+            "--filter",
+            "protanopia",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "--audio + --filter must fail");
+}


### PR DESCRIPTION
## 概要
P1 #105。聴覚モジュール全体（15 フィルタ）と `AudioPipeline` が **CLI から一切叩けず**、Cargo.toml の description が "hearing loss" を宣伝しながら binary では到達不可だった矛盾を解消。

## 変更
- `--audio <in.wav> --hearing <filter>... -o <out.wav>`: WAV を読み、`--hearing` を `AudioPipeline` で順に適用して WAV 出力。
- `--freq`（tinnitus / sudden-hearing-loss / misophonia）/ `--semitones`（pitch-shift）。
- WAV I/O は `hound`（`crates/cli/src/audio.rs`）。整数/浮動小数 PCM を正規化 f32 で読み、出力時に入力の bit 深度・形式へ戻す。チャンネル数は適用後バッファに追従（diplacusis mono→stereo）。**WAV のみ**（mp3/flac 非対象）。
- `--audio` は `--input`/`--filter`/`--pipe`/`--mpo`/`--portrait` と排他。`--hearing`/`-o` 無しは明示エラー。

## テスト
- 統合テスト `audio_integration.rs` 5 件: hearing-loss が 8 kHz を減衰 / チェーン / --hearing 無しで失敗 / diplacusis mono→stereo / --filter 併用で失敗
- 全 workspace test green、clippy クリーン、README（CLI usage・フラグ表・hearing/Experience）更新

closes #105