### PR TITLE
feat: #106 cataract に輝度・コントラスト低下を追加（VIP-Sim 二段モデル）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **feat: kako-jun/sensus#106 cataract に輝度・コントラスト低下を追加（VIP-Sim 二段モデルの未移植分）**: これまで黄変マトリクス + 白濁ノイズのみで、白内障の霞み感の核である輝度・コントラスト低下が移植されていなかった。VIP-Sim の BrightnessContrast 段に倣い、linear sRGB 空間で pivot 0.5 中心の per-channel コントラスト収縮（ContrastCoeff = (0.7, 0.7, 0.4)、青の散乱が最大）+ severity 比例の輝度低下を追加。`c_ch = 1 - s*(1 - coeff_ch)` で strength=0 のとき恒等。**CPU `vision::cataract` / `cataract.frag` / `sim_cataract_glsl` の 3 箇所に同一演算で実装し、既存の CPU↔GLSL 等価テスト（PSNR ≥ 30 dB）を維持**。効果アサート `cataract_reduces_brightness_and_contrast`（白黒 1×1 の輝度差が圧縮されることを検証）。
+
 - **feat: kako-jun/sensus#105 聴覚フィルタ + AudioPipeline を CLI から利用可能に（`--audio` / WAV）**: 聴覚モジュール全体（15 フィルタ）と `AudioPipeline` が CLI から一切叩けず、Cargo.toml の description が "hearing loss" を宣伝しながら binary では到達不可だった矛盾を解消。
   - `--audio <in.wav> --hearing <filter>... -o <out.wav>`: WAV を読み、`--hearing` の聴覚フィルタを `AudioPipeline` で順に適用して WAV 出力。`--hearing` は複数指定でチェーン可。パラメータ付きフィルタ用に `--freq`（tinnitus/sudden-hearing-loss/misophonia）と `--semitones`（pitch-shift）を追加。
   - WAV I/O は `hound` で実装（`crates/cli/src/audio.rs`）。整数/浮動小数 PCM を正規化 f32 で読み、出力時に入力の bit 深度・形式へ戻す。チャンネル数は適用後バッファに追従（diplacusis の mono→stereo を保つ）。**mp3/flac 等の広域デコードは非対象**。

--- a/crates/core/src/shaders/cataract.frag
+++ b/crates/core/src/shaders/cataract.frag
@@ -90,6 +90,15 @@ void main() {
     float ng = g + (yg - g) * uStrength;
     float nb = b + (yb - b) * uStrength;
 
+    // VIP-Sim 二段モデルの輝度・コントラスト低下（#106）。
+    // pivot 0.5 中心の per-channel コントラスト収縮（ContrastCoeff = 0.7, 0.7, 0.4）
+    // + 輝度低下。CPU vision::cataract と同一演算。
+    const float PIVOT = 0.5;
+    const float BRIGHTNESS_DROP = 0.1;
+    nr = clamp((nr - PIVOT) * (1.0 - uStrength * (1.0 - 0.7)) + PIVOT - uStrength * BRIGHTNESS_DROP, 0.0, 1.0);
+    ng = clamp((ng - PIVOT) * (1.0 - uStrength * (1.0 - 0.7)) + PIVOT - uStrength * BRIGHTNESS_DROP, 0.0, 1.0);
+    nb = clamp((nb - PIVOT) * (1.0 - uStrength * (1.0 - 0.4)) + PIVOT - uStrength * BRIGHTNESS_DROP, 0.0, 1.0);
+
     // 32bit spatial hash 格子補間ノイズによる白濁
     // CPU の整数ピクセル座標 (x, y) を復元（フラグメント中心 uv = (x+0.5)/res）。
     vec2 pixelPos = vTexCoord * uResolution - 0.5;

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -657,6 +657,9 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
     const WHITE_BLEND_MAX: f32 = 0.4;
     // 格子セルサイズ（旧 BLOCK_SIZE=8 より大きい 32px で空間相関を確保）
     const CELL_SIZE: f32 = 32.0;
+    // VIP-Sim 二段モデルのコントラスト/輝度低下（#106）。
+    const CATARACT_PIVOT: f32 = 0.5;
+    const CATARACT_BRIGHTNESS_DROP: f32 = 0.1;
 
     // 格子頂点ごとの白濁ノイズ値を 32bit 整数 spatial hash で生成する。
     //
@@ -736,6 +739,23 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
             let nr = r + (yr - r) * strength;
             let ng = g + (yg - g) * strength;
             let nb = b + (yb - b) * strength;
+
+            // VIP-Sim 二段モデルの未移植分（#106）: severity 比例の輝度・コントラスト低下。
+            // 白内障の霞み感の核。pivot 0.5 を中心にコントラストを per-channel 収縮させ
+            // （ContrastCoeff = (0.7, 0.7, 0.4)、青の散乱が最大）、全体輝度を僅かに下げる。
+            // c_ch = 1 - s*(1 - coeff_ch) で strength=0 のとき恒等。CPU/GLSL/sim で同一演算。
+            let nr = ((nr - CATARACT_PIVOT) * (1.0 - strength * (1.0 - 0.7))
+                + CATARACT_PIVOT
+                - strength * CATARACT_BRIGHTNESS_DROP)
+                .clamp(0.0, 1.0);
+            let ng = ((ng - CATARACT_PIVOT) * (1.0 - strength * (1.0 - 0.7))
+                + CATARACT_PIVOT
+                - strength * CATARACT_BRIGHTNESS_DROP)
+                .clamp(0.0, 1.0);
+            let nb = ((nb - CATARACT_PIVOT) * (1.0 - strength * (1.0 - 0.4))
+                + CATARACT_PIVOT
+                - strength * CATARACT_BRIGHTNESS_DROP)
+                .clamp(0.0, 1.0);
 
             // Simplex-like ノイズによる白濁（空間相関あり）
             let noise = grid_sample(x, y);
@@ -4024,6 +4044,27 @@ mod tests {
         assert_eq!(
             raw_rgba_vec(&cataract(input, f32::NAN, 42).unwrap()),
             original
+        );
+    }
+
+    #[test]
+    fn cataract_reduces_brightness_and_contrast() {
+        // #106: VIP-Sim 二段モデルの輝度・コントラスト低下。
+        // 1x1 の白と黒（同一座標なので白濁ノイズは共通）で輝度差が縮むことを確認する。
+        let white = cataract(solid_rgba(1, 1, [255, 255, 255, 255]), 1.0, 42).unwrap();
+        let black = cataract(solid_rgba(1, 1, [0, 0, 0, 255]), 1.0, 42).unwrap();
+        let w = raw_rgba_vec(&white);
+        let b = raw_rgba_vec(&black);
+        let w_sum: i32 = w[0..3].iter().map(|&v| v as i32).sum();
+        let b_sum: i32 = b[0..3].iter().map(|&v| v as i32).sum();
+        // 白は最大未満まで下がる（コントラスト収縮 + 輝度低下）
+        assert!(w_sum < 255 * 3, "cataract should dim pure white: sum={w_sum}");
+        // 黒は白濁ヴェールで持ち上がる
+        assert!(b_sum > 0, "cataract veil should lift pure black: sum={b_sum}");
+        // 白黒の輝度差（コントラスト）が元の最大 (255*3) より縮む
+        assert!(
+            (w_sum - b_sum) < 255 * 3,
+            "cataract should compress contrast: white_sum={w_sum}, black_sum={b_sum}"
         );
     }
 

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -3764,6 +3764,16 @@ fn sim_cataract_glsl(img: &RgbaImage, strength: f32, seed: u32) -> RgbaImage {
             let ng = g + (yg - g) * strength;
             let nb = b + (yb - b) * strength;
 
+            // #106: VIP-Sim 二段モデルの輝度・コントラスト低下（.frag / CPU と同一）
+            const PIVOT: f32 = 0.5;
+            const BRIGHTNESS_DROP: f32 = 0.1;
+            let nr = ((nr - PIVOT) * (1.0 - strength * (1.0 - 0.7)) + PIVOT - strength * BRIGHTNESS_DROP)
+                .clamp(0.0, 1.0);
+            let ng = ((ng - PIVOT) * (1.0 - strength * (1.0 - 0.7)) + PIVOT - strength * BRIGHTNESS_DROP)
+                .clamp(0.0, 1.0);
+            let nb = ((nb - PIVOT) * (1.0 - strength * (1.0 - 0.4)) + PIVOT - strength * BRIGHTNESS_DROP)
+                .clamp(0.0, 1.0);
+
             // pixelPos = vTexCoord * uResolution - 0.5 = (x, y)（整数ピクセル座標）
             let noise = smooth_noise(x as f32, y as f32);
             const WHITE_BLEND_MAX: f32 = 0.4;


### PR DESCRIPTION
## 概要
P1 #106。VIP-Sim の cataract は黄変 + frost に加え **BrightnessContrast 段**（Brightness/Contrast = severity比例、ContrastCoeff (0.7,0.7,0.4)）の二段モデルだが、sensus は黄変マトリクス + 白濁ノイズのみで、**白内障の霞み感の核である輝度・コントラスト低下が未移植**だった。

## 変更
linear sRGB 空間で、黄変ブレンド後・白濁ヴェール前に:
- pivot 0.5 中心の per-channel コントラスト収縮（ContrastCoeff = (0.7, 0.7, 0.4)、青の散乱が最大）
- severity 比例の輝度低下（BRIGHTNESS_DROP = 0.1）
- `c_ch = 1 - s*(1 - coeff_ch)` で strength=0 のとき恒等

**CPU `vision::cataract` / `cataract.frag` / 等価テスト `sim_cataract_glsl` の 3 箇所に同一演算で実装。**

## テスト
- 既存の CPU↔GLSL 等価テスト（PSNR ≥ 30 dB、strength 1.0 / 0.5 / 非正方形 / seed 差）を**維持**
- 効果アサート `cataract_reduces_brightness_and_contrast`: 白黒 1×1 の輝度差がコントラスト収縮で圧縮されることを検証
- strength=0 / NaN 恒等は不変

closes #106