### PR TITLE
feat: #107 depth_aware_blur の GLSL シェーダを追加（移植の残り半分）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **feat: kako-jun/sensus#107 depth_aware_blur の GLSL シェーダを追加（移植の残り半分）**: `vision::depth_aware_blur` は CPU 実装・ユニットテスト済みだったが GLSL シェーダが無く、universal-experience の Flutter FragmentProgram 経路から到達できなかった。`depth_aware_blur.frag` + `shaders::depth_aware_blur_glsl()` + `depth_aware_blur_uniforms()` を追加。深度マップを `uDepth` テクスチャで渡す単一パスシェーダで、per-fragment に深度から半径を求め Fibonacci lattice 16 tap disk（eye_strain/photophobia と同方式）で円盤近似ブラー。CPU は 8 ビン box blur の多パスと算法が異なるため bit/PSNR 等価は取らず、`.frag` 忠実ミラー sim で効果（ピント面鮮明 / 離れるほどぼける / kind による前後選択 / DoF 両側）を検証（5 件）。**`Filter` enum/apply() には載せない判断**: 深度ブラーは深度マップという第 2 入力を要し、`Copy` な単一入力 `Filter`/`apply(filter,img,strength)` 契約に収まらないため。consumer は Rust=`vision::depth_aware_blur`（既に pub）/ GLSL=`*_glsl()` + `uDepth` で到達する（doc に明記）。
+
 - **feat: kako-jun/sensus#106 cataract に輝度・コントラスト低下を追加（VIP-Sim 二段モデルの未移植分）**: これまで黄変マトリクス + 白濁ノイズのみで、白内障の霞み感の核である輝度・コントラスト低下が移植されていなかった。VIP-Sim の BrightnessContrast 段に倣い、linear sRGB 空間で pivot 0.5 中心の per-channel コントラスト収縮（ContrastCoeff = (0.7, 0.7, 0.4)、青の散乱が最大）+ severity 比例の輝度低下を追加。`c_ch = 1 - s*(1 - coeff_ch)` で strength=0 のとき恒等。**CPU `vision::cataract` / `cataract.frag` / `sim_cataract_glsl` の 3 箇所に同一演算で実装し、既存の CPU↔GLSL 等価テスト（PSNR ≥ 30 dB）を維持**。効果アサート `cataract_reduces_brightness_and_contrast`（白黒 1×1 の輝度差が圧縮されることを検証）。
 
 - **feat: kako-jun/sensus#105 聴覚フィルタ + AudioPipeline を CLI から利用可能に（`--audio` / WAV）**: 聴覚モジュール全体（15 フィルタ）と `AudioPipeline` が CLI から一切叩けず、Cargo.toml の description が "hearing loss" を宣伝しながら binary では到達不可だった矛盾を解消。

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -820,6 +820,58 @@ pub fn metamorphopsia_uniforms(
     }
 }
 
+/// depth_aware_blur.frag の GLSL ES 3.00 ソースを返す（#107）。
+///
+/// 深度マップを第 2 テクスチャ（`uDepth`）として渡す単一パスシェーダ。
+/// `uDepth` の `.r` を深度（明=近、暗=遠）として読む（CPU の `to_luma8` 相当の
+/// grayscale 深度を host 側で渡すこと）。CPU 実装 `vision::depth_aware_blur` は
+/// 8 段階ビン box blur の多パス方式なので、本シェーダ（Fibonacci 16 tap disk）とは
+/// アルゴリズムが異なり bit/PSNR 等価ではない。効果（ピント面鮮明・離れるほどぼける）で担保する。
+pub fn depth_aware_blur_glsl() -> &'static str {
+    include_str!("shaders/depth_aware_blur.frag")
+}
+
+/// depth_aware_blur フィルタの uniform（#107）。
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DepthAwareBlurUniforms {
+    /// ピント深度（0.0..=1.0）。depth_aware_blur.frag の `uFocusDepth`。
+    pub focus_depth: f32,
+    /// 最大ぼけ半径（ピクセル単位）= `max_radius_ratio * min(width, height)`。`uMaxRadiusPx`。
+    pub max_radius_px: f32,
+    /// ぼけ種別。0=Myopia(遠方ボケ), 1=Hyperopia(近方ボケ), 2=DepthOfField(両側)。`uKind`。
+    pub kind: i32,
+    /// テクセルサイズ vec2(1.0/width, 1.0/height)。`uTexelSize`。
+    pub texel_size: [f32; 2],
+}
+
+/// depth_aware_blur の uniform を返す。
+///
+/// `focus_depth`: ピント深度（0.0..=1.0）。
+/// `max_radius_ratio`: 最大ぼけ半径（min(W,H) 比）。CPU `vision::depth_aware_blur` に
+///   渡す値と同じものを渡すこと（CLI は `strength * 0.023`）。
+/// `kind`: [`crate::vision::DepthBlurKind`]。
+pub fn depth_aware_blur_uniforms(
+    focus_depth: f32,
+    max_radius_ratio: f32,
+    kind: crate::vision::DepthBlurKind,
+    width: u32,
+    height: u32,
+) -> DepthAwareBlurUniforms {
+    use crate::vision::DepthBlurKind;
+    let min_dim = width.min(height) as f32;
+    let kind_i = match kind {
+        DepthBlurKind::Myopia => 0,
+        DepthBlurKind::Hyperopia => 1,
+        DepthBlurKind::DepthOfField => 2,
+    };
+    DepthAwareBlurUniforms {
+        focus_depth,
+        max_radius_px: max_radius_ratio * min_dim,
+        kind: kind_i,
+        texel_size: [1.0 / width as f32, 1.0 / height as f32],
+    }
+}
+
 // ---------------------------------------------------------------------------
 // テスト
 // ---------------------------------------------------------------------------
@@ -1014,5 +1066,24 @@ mod tests {
         assert_eq!(u.side, 1.0);
         let u2 = hemianopia_uniforms(1.0, -1.0);
         assert_eq!(u2.side, -1.0);
+    }
+
+    #[test]
+    fn depth_aware_blur_glsl_is_not_empty() {
+        assert!(depth_aware_blur_glsl().contains("uDepth"));
+        assert!(depth_aware_blur_glsl().contains("void main"));
+    }
+
+    #[test]
+    fn depth_aware_blur_uniforms_kind_and_radius() {
+        use crate::vision::DepthBlurKind;
+        let u = depth_aware_blur_uniforms(0.5, 0.023, DepthBlurKind::Myopia, 100, 200);
+        assert_eq!(u.kind, 0);
+        assert_eq!(u.focus_depth, 0.5);
+        // max_radius_px = ratio * min(w,h) = 0.023 * 100
+        assert!((u.max_radius_px - 2.3).abs() < 1e-5);
+        assert!((u.texel_size[0] - 0.01).abs() < 1e-6);
+        assert_eq!(depth_aware_blur_uniforms(0.5, 0.023, DepthBlurKind::Hyperopia, 100, 200).kind, 1);
+        assert_eq!(depth_aware_blur_uniforms(0.5, 0.023, DepthBlurKind::DepthOfField, 100, 200).kind, 2);
     }
 }

--- a/crates/core/src/shaders/depth_aware_blur.frag
+++ b/crates/core/src/shaders/depth_aware_blur.frag
@@ -1,0 +1,75 @@
+#version 300 es
+precision highp float;
+
+// 深度マップ付き距離依存ぼけ（depth-aware defocus blur）。
+// CPU 実装 vision::depth_aware_blur に対応する GLSL 経路（#107）。
+//
+// CPU は 8 段階の深度ビンごとに ellipse_blur（box 状）を生成して線形補間する
+// 多パス方式だが、GPU は単一パスで処理するため、各フラグメントで深度から
+// ぼけ半径を直接求め、eye_strain.frag / photophobia.frag と同じ Fibonacci lattice
+// 16 tap で円盤（pillbox）を近似サンプリングする。アルゴリズムが異なるため
+// CPU との bit / PSNR 等価は取らず、効果（ピント面は鮮明・離れるほどぼける・
+// kind による前後選択）を shader_equivalence の sim ミラーで検証する。
+//
+// 深度マップは grayscale（CPU は to_luma8）を想定し、ここでは .r を深度として読む。
+// 明るい（1.0）= 近い、暗い（0.0）= 遠い。
+
+uniform sampler2D uTexture;
+uniform sampler2D uDepth;
+uniform float uFocusDepth;   // ピント深度（0.0..=1.0）
+uniform float uMaxRadiusPx;  // 最大ぼけ半径（px）= max_radius_ratio * min(W,H)
+uniform int uKind;           // 0=Myopia(遠方ボケ), 1=Hyperopia(近方ボケ), 2=DepthOfField(両側)
+uniform vec2 uTexelSize;     // vec2(1.0/width, 1.0/height)
+
+in vec2 vTexCoord;
+out vec4 fragColor;
+
+// blur が視認できない最小半径（CPU の MIN_BLUR_RADIUS_PX と一致）
+const float kMinRadiusPx = 0.5;
+
+float srgbToLinear(float c) {
+    return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
+}
+float linearToSrgb(float c) {
+    return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+void main() {
+    vec4 c = texture(uTexture, vTexCoord);
+    float depth = texture(uDepth, vTexCoord).r;
+    float delta = depth - uFocusDepth;
+
+    float radiusPx;
+    if (uKind == 0) {
+        // Myopia: 遠方（depth < focus, delta < 0）がボケる
+        radiusPx = delta < 0.0 ? (-delta) * uMaxRadiusPx : 0.0;
+    } else if (uKind == 1) {
+        // Hyperopia: 近方（depth > focus, delta > 0）がボケる
+        radiusPx = delta > 0.0 ? delta * uMaxRadiusPx : 0.0;
+    } else {
+        // DepthOfField: 両側がボケる
+        radiusPx = abs(delta) * uMaxRadiusPx;
+    }
+
+    if (radiusPx < kMinRadiusPx) {
+        // ピント面付近は鮮明（blur なし）
+        fragColor = c;
+        return;
+    }
+
+    // Fibonacci lattice 16 tap で円盤内を均等サンプリングし linear 空間で平均する。
+    const int N = 16;
+    const float PHI = 2.399963229728653; // 黄金角 ≈ 137.508°
+    vec3 acc = vec3(0.0);
+    for (int i = 0; i < N; i++) {
+        float ft = float(i) / float(N);
+        float r = sqrt(ft) * radiusPx;
+        float theta = float(i) * PHI;
+        vec2 offset = vec2(cos(theta), sin(theta)) * r * uTexelSize;
+        vec3 s = texture(uTexture, vTexCoord + offset).rgb;
+        acc += vec3(srgbToLinear(s.r), srgbToLinear(s.g), srgbToLinear(s.b));
+    }
+    vec3 result = acc / float(N);
+
+    fragColor = vec4(linearToSrgb(result.r), linearToSrgb(result.g), linearToSrgb(result.b), c.a);
+}

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -1778,6 +1778,17 @@ pub enum DepthBlurKind {
 /// ```
 ///
 /// メモリは 8 枚同時保持から 2 枚逐次処理に変更し、アーティファクトを除去する。
+///
+/// # consumer からの到達経路（#107）
+///
+/// 深度ブラーは深度マップという第 2 入力を要するため、単一入力契約の
+/// [`crate::Filter`] / [`crate::apply`] には載せていない（`Filter` は `Copy` で、
+/// 画像を抱える深度マップを variant に入れられない）。consumer は次の 2 経路で到達する:
+/// - Rust ライブラリ: 本関数 `depth_aware_blur` を直接呼ぶ（既に `pub`）。
+/// - GLSL（universal-experience の Flutter 経路）: [`crate::shaders::depth_aware_blur_glsl`]
+///   + [`crate::shaders::depth_aware_blur_uniforms`]。深度マップを `uDepth` テクスチャで渡す。
+///   CPU は 8 ビン box blur の多パス、GLSL は per-fragment Fibonacci 16 tap disk と算法が
+///   異なるため bit/PSNR 等価ではなく、効果（ピント面鮮明・離れるほどぼける・kind 選択）で担保。
 pub fn depth_aware_blur(
     img: DynamicImage,
     depth_map: &DynamicImage,

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -4030,3 +4030,172 @@ fn glaucoma_arcuate_strength_0_0_is_identity() {
         "glaucoma 弧状 strength=0.0 は恒等でなければならない"
     );
 }
+
+// ===========================================================================
+// #107: depth_aware_blur GLSL（効果検証）
+//
+// CPU vision::depth_aware_blur は 8 ビン box blur の多パス、GLSL は per-fragment
+// Fibonacci 16 tap disk と算法が異なるため CPU との PSNR 等価は取らない。
+// .frag を忠実ミラーする sim を作り「ピント面は鮮明・離れるほどぼける・kind 選択」を検証する。
+// ===========================================================================
+
+/// depth_aware_blur.frag の忠実ミラー。
+/// `depth` は grayscale RGBA（.r を深度として読む）。`kind`: 0=Myopia,1=Hyperopia,2=DoF。
+fn sim_depth_aware_blur_glsl(
+    img: &RgbaImage,
+    depth: &RgbaImage,
+    focus_depth: f32,
+    max_radius_px: f32,
+    kind: i32,
+) -> RgbaImage {
+    const N: usize = 16;
+    const PHI: f32 = 2.399_963_2;
+    const MIN_RADIUS_PX: f32 = 0.5;
+    let (w, h) = img.dimensions();
+    let texel_w = 1.0 / w as f32;
+    let texel_h = 1.0 / h as f32;
+
+    // texture() の nearest + clamp-to-edge サンプリング（linear sRGB を返す）
+    let sample_lin = |u: f32, v: f32| -> [f32; 3] {
+        let px_x = ((u * w as f32).round() as i32).clamp(0, w as i32 - 1) as u32;
+        let px_y = ((v * h as f32).round() as i32).clamp(0, h as i32 - 1) as u32;
+        let px = img.get_pixel(px_x, px_y);
+        [
+            srgb_to_linear(px[0] as f32 / 255.0),
+            srgb_to_linear(px[1] as f32 / 255.0),
+            srgb_to_linear(px[2] as f32 / 255.0),
+        ]
+    };
+
+    let mut out = img.clone();
+    for y in 0..h {
+        for x in 0..w {
+            let u = (x as f32 + 0.5) / w as f32;
+            let v = (y as f32 + 0.5) / h as f32;
+            let d = depth.get_pixel(x, y)[0] as f32 / 255.0;
+            let delta = d - focus_depth;
+            let radius_px = match kind {
+                0 => if delta < 0.0 { -delta * max_radius_px } else { 0.0 },
+                1 => if delta > 0.0 { delta * max_radius_px } else { 0.0 },
+                _ => delta.abs() * max_radius_px,
+            };
+
+            let px = img.get_pixel(x, y);
+            if radius_px < MIN_RADIUS_PX {
+                out.put_pixel(x, y, *px);
+                continue;
+            }
+            let mut acc = [0f32; 3];
+            for i in 0..N {
+                let ft = i as f32 / N as f32;
+                let r = ft.sqrt() * radius_px;
+                let theta = i as f32 * PHI;
+                let s = sample_lin(u + theta.cos() * r * texel_w, v + theta.sin() * r * texel_h);
+                acc[0] += s[0];
+                acc[1] += s[1];
+                acc[2] += s[2];
+            }
+            out.put_pixel(
+                x,
+                y,
+                image::Rgba([
+                    (linear_to_srgb(acc[0] / N as f32) * 255.0).round() as u8,
+                    (linear_to_srgb(acc[1] / N as f32) * 255.0).round() as u8,
+                    (linear_to_srgb(acc[2] / N as f32) * 255.0).round() as u8,
+                    px[3],
+                ]),
+            );
+        }
+    }
+    out
+}
+
+/// 高周波チェッカーボード（blur が検出しやすい）。
+fn checkerboard_32() -> RgbaImage {
+    let mut img = RgbaImage::new(32, 32);
+    for y in 0..32u32 {
+        for x in 0..32u32 {
+            let v = if (x + y) % 2 == 0 { 255 } else { 0 };
+            img.put_pixel(x, y, image::Rgba([v, v, v, 255]));
+        }
+    }
+    img
+}
+
+/// 一様深度の grayscale RGBA を作る。
+fn solid_depth_32(depth: f32) -> RgbaImage {
+    let d = (depth.clamp(0.0, 1.0) * 255.0).round() as u8;
+    RgbaImage::from_pixel(32, 32, image::Rgba([d, d, d, 255]))
+}
+
+fn abs_diff_sum(a: &RgbaImage, b: &RgbaImage) -> u64 {
+    a.as_raw()
+        .iter()
+        .zip(b.as_raw().iter())
+        .map(|(&x, &y)| (x as i32 - y as i32).unsigned_abs() as u64)
+        .sum()
+}
+
+#[test]
+fn depth_aware_blur_glsl_focus_plane_is_sharp() {
+    // depth == focus → 全画素 radius 0 → 恒等（ピント面は鮮明）
+    let img = checkerboard_32();
+    let depth = solid_depth_32(0.5);
+    let out = sim_depth_aware_blur_glsl(&img, &depth, 0.5, 8.0, 0);
+    assert_eq!(abs_diff_sum(&img, &out), 0, "focus plane must stay sharp (identity)");
+}
+
+#[test]
+fn depth_aware_blur_glsl_myopia_blurs_far_not_near() {
+    let img = checkerboard_32();
+    // Myopia(kind=0): 遠方(depth<focus)がボケる。
+    let far = solid_depth_32(0.0); // delta = -1 → blur
+    let blurred = sim_depth_aware_blur_glsl(&img, &far, 1.0, 8.0, 0);
+    assert!(
+        abs_diff_sum(&img, &blurred) > 0,
+        "myopia must blur the far plane (depth<focus)"
+    );
+
+    // 近方(depth>focus)は鮮明のまま
+    let near = solid_depth_32(1.0); // focus 0.0 → delta = +1, Myopia は前方ボケなし
+    let sharp = sim_depth_aware_blur_glsl(&img, &near, 0.0, 8.0, 0);
+    assert_eq!(abs_diff_sum(&img, &sharp), 0, "myopia must keep the near plane sharp");
+}
+
+#[test]
+fn depth_aware_blur_glsl_hyperopia_blurs_near_not_far() {
+    let img = checkerboard_32();
+    // Hyperopia(kind=1): 近方(depth>focus)がボケる。
+    let near = solid_depth_32(1.0); // focus 0.0 → delta = +1 → blur
+    let blurred = sim_depth_aware_blur_glsl(&img, &near, 0.0, 8.0, 1);
+    assert!(
+        abs_diff_sum(&img, &blurred) > 0,
+        "hyperopia must blur the near plane (depth>focus)"
+    );
+    // 遠方は鮮明
+    let far = solid_depth_32(0.0); // focus 1.0 → delta = -1, Hyperopia は後方ボケなし
+    let sharp = sim_depth_aware_blur_glsl(&img, &far, 1.0, 8.0, 1);
+    assert_eq!(abs_diff_sum(&img, &sharp), 0, "hyperopia must keep the far plane sharp");
+}
+
+#[test]
+fn depth_aware_blur_glsl_dof_blurs_both_sides() {
+    let img = checkerboard_32();
+    // DoF(kind=2): focus から離れた両側がボケる。
+    let far = sim_depth_aware_blur_glsl(&img, &solid_depth_32(0.0), 0.5, 8.0, 2);
+    let near = sim_depth_aware_blur_glsl(&img, &solid_depth_32(1.0), 0.5, 8.0, 2);
+    assert!(abs_diff_sum(&img, &far) > 0, "DoF must blur far side");
+    assert!(abs_diff_sum(&img, &near) > 0, "DoF must blur near side");
+}
+
+#[test]
+fn depth_aware_blur_glsl_larger_distance_blurs_more() {
+    // ピントから遠いほど（delta 大）ぼけが強い（blur 差分が単調増加）
+    let img = checkerboard_32();
+    let mild = sim_depth_aware_blur_glsl(&img, &solid_depth_32(0.4), 1.0, 8.0, 0); // delta -0.6
+    let strong = sim_depth_aware_blur_glsl(&img, &solid_depth_32(0.0), 1.0, 8.0, 0); // delta -1.0
+    assert!(
+        abs_diff_sum(&img, &strong) >= abs_diff_sum(&img, &mild),
+        "farther-from-focus depth must blur at least as much"
+    );
+}


### PR DESCRIPTION
## 概要
P1 #107。`vision::depth_aware_blur` は CPU 実装・ユニットテスト済みだったが **GLSL シェーダが無く**、universal-experience の Flutter FragmentProgram 経路から到達できなかった（仕様の半分のみ移植）。

## 変更
- `crates/core/src/shaders/depth_aware_blur.frag`: 深度マップを `uDepth` テクスチャで渡す単一パスシェーダ。per-fragment に深度から半径を求め、Fibonacci lattice 16 tap disk（eye_strain/photophobia と同方式）で円盤近似ブラー。
- `shaders::depth_aware_blur_glsl()` + `DepthAwareBlurUniforms` + `depth_aware_blur_uniforms(focus, ratio, kind, w, h)`。

## Filter enum/apply() に載せない判断
深度ブラーは**深度マップという第 2 入力**を要し、`Copy` な単一入力 `Filter` / `apply(filter, img, strength)` 契約に収まらない（画像を抱える深度マップを variant に入れられない）。consumer の到達経路:
- Rust ライブラリ: `vision::depth_aware_blur`（既に pub）
- GLSL: `depth_aware_blur_glsl()` + `uDepth` テクスチャ

doc コメントに明記。

## テスト
CPU（8 ビン box 多パス）と GLSL（per-fragment disk）は算法が異なり bit/PSNR 等価不成立のため、`.frag` 忠実ミラー sim で**効果**を検証:
- ピント面（depth==focus）は鮮明（恒等）/ Myopia は遠方のみボケ近方鮮明 / Hyperopia は近方のみボケ / DoF 両側 / 離れるほど強くボケる
- uniforms の kind→i32・半径算出

closes #107