### PR TITLE
fix: #134 flickering_stars を CPU↔GLSL 統一（floaters は #141 に分離）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **fix: kako-jun/sensus#134 flickering_stars のノイズを CPU↔GLSL で統一（floaters は parity 不能を明文化）**:
+  - **flickering_stars**: CPU の 64bit LCG（`(state>>32)` 抽出・32bit GPU で再現不能）を、点 index ベースの 32bit spatial hash（`vision::star_hash32`、#99/#125 cataract と同系列の黄金比混合 + XOR-shift）に統一。`flickering_stars.frag` も旧 Wang hash + 円形 distance + 合計後クランプから、同一 hash + 整数ピクセル中心の 5×5 正方ボックス + **点ごとの min(1.0) クランプ**（CPU と同順・同演算）に書き換え。点数は float 再計算による不一致を避けるため `FlickeringStarsUniforms.count`（= `(strength*200) as i32`）として渡す。`sim_flickering_stars_glsl` 忠実ミラーで CPU↔GLSL **PSNR ≥ 40 dB**（strength 1.0 / 0.5 非正方形 / seed 差）を検証。
+  - **floaters**: 単一パス GLSL での CPU 忠実再現は不能と判断・明文化。理由は (1) 乱歩ストランドがデータ依存の RNG ストリームを逐次消費し、(2) 最終マスクに 3×3 box blur を掛けるため、200 点ぶんのストランドを毎フラグメントで replay しつつ 9 近傍マスクを再計算する必要があり実機描画として非現実的。`floaters.frag` を意図的近似のまま据え置き、真の parity に必要な設計判断（blob-only モデルへの統一 or CPU 生成マスクのテクスチャ受け渡し）を follow-up として分離。
+
 ### Added
 
 - **feat: kako-jun/sensus#107 depth_aware_blur の GLSL シェーダを追加（移植の残り半分）**: `vision::depth_aware_blur` は CPU 実装・ユニットテスト済みだったが GLSL シェーダが無く、universal-experience の Flutter FragmentProgram 経路から到達できなかった。`depth_aware_blur.frag` + `shaders::depth_aware_blur_glsl()` + `depth_aware_blur_uniforms()` を追加。深度マップを `uDepth` テクスチャで渡す単一パスシェーダで、per-fragment に深度から半径を求め Fibonacci lattice 16 tap disk（eye_strain/photophobia と同方式）で円盤近似ブラー。CPU は 8 ビン box blur の多パスと算法が異なるため bit/PSNR 等価は取らず、`.frag` 忠実ミラー sim で効果（ピント面鮮明 / 離れるほどぼける / kind による前後選択 / DoF 両側）を検証（5 件）。**`Filter` enum/apply() には載せない判断**: 深度ブラーは深度マップという第 2 入力を要し、`Copy` な単一入力 `Filter`/`apply(filter,img,strength)` 契約に収まらないため。consumer は Rust=`vision::depth_aware_blur`（既に pub）/ GLSL=`*_glsl()` + `uDepth` で到達する（doc に明記）。

--- a/crates/core/src/shaders.rs
+++ b/crates/core/src/shaders.rs
@@ -213,6 +213,8 @@ pub fn flickering_stars_uniforms(strength: f32, seed: u64) -> FlickeringStarsUni
     FlickeringStarsUniforms {
         strength,
         seed: seed as u32,
+        // CPU vision::flickering_stars と同じ点数算出（strength*200 の切り捨て）。
+        count: (strength.clamp(0.0, 1.0) * 200.0) as i32,
     }
 }
 
@@ -255,6 +257,9 @@ pub struct FlickeringStarsUniforms {
     pub strength: f32,
     /// ランダムシード（CPU u64 の下位 32bit、M-3）
     pub seed: u32,
+    /// 光点数 = `(strength * 200) as usize`（#134）。
+    /// CPU の点数と完全に一致させるため float から再計算せず int として渡す。
+    pub count: i32,
 }
 
 /// photophobia フィルタの uniform。

--- a/crates/core/src/shaders/flickering_stars.frag
+++ b/crates/core/src/shaders/flickering_stars.frag
@@ -1,63 +1,69 @@
 #version 300 es
-precision mediump float;
+precision highp float;
+precision highp int;
+
+// 閃輝暗点・光の星（Flickering stars）シミュレーション。
+// CPU 実装 vision::flickering_stars と同一のモデル（#134 で CPU↔GLSL を統一）。
+//
+// 点 i ごとに 32bit spatial hash（star_hash32）で位置(fx,fy)と輝度を生成し、
+// 整数ピクセル中心の 5×5 正方ボックス（|dx|<=2 && |dy|<=2）内の画素に
+// linear sRGB 空間で輝度を加算する。加算は点ごとに min(1.0) でクランプする
+// （= CPU の per-star clamp と同順・同演算）。
+//
+// 旧実装は Wang hash + 円形 distance + 合計後クランプで、CPU の 64bit LCG +
+// 正方ボックス + per-star clamp と乖離していた（#134）。
+
 uniform sampler2D uTexture;
 uniform float uStrength;
-uniform uint uSeed;
+uniform uint uSeed;       // u64 シードの下位 32bit
+uniform int uCount;       // 点数 = (strength * 200) as usize（CPU 側で算出して渡す）
 uniform vec2 uResolution;
+
 in vec2 vTexCoord;
 out vec4 fragColor;
 
-// uint ベースのハッシュ（精度劣化なし）
-// Wang hash
-uint hash_uint(uint n) {
-    n = (n ^ 61u) ^ (n >> 16u);
-    n *= 9u;
-    n = n ^ (n >> 4u);
-    n *= 0x27d4eb2du;
-    n = n ^ (n >> 15u);
-    return n;
+// #134: CPU vision::star_hash32 と同一の 32bit hash（cataract gridNoise と同系列）。
+uint starHash(uint seed, uint k) {
+    uint h = seed * 0x9e3779b9u + k * 0x85ebca6bu;
+    h ^= h >> 15;
+    h *= 0x2c1b3c6du;
+    h ^= h >> 12;
+    h *= 0x297a2d39u;
+    h ^= h >> 15;
+    return h;
+}
+float hash01(uint k) {
+    return float(starHash(uSeed, k)) / float(0xFFFFFFFFu); // 0.0..=1.0
 }
 
-// [0, 1) の float に変換
-float hash_to_float(uint h) {
-    return float(h & 0x00ffffffu) / float(0x01000000u);
-}
-
-// sRGB -> linear
-float srgb_to_linear(float c) {
+float srgbToLinear(float c) {
     return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4);
 }
-// linear -> sRGB
-float linear_to_srgb(float c) {
+float linearToSrgb(float c) {
     return c <= 0.0031308 ? c * 12.92 : 1.055 * pow(c, 1.0 / 2.4) - 0.055;
 }
 
 void main() {
     vec4 c = texture(uTexture, vTexCoord);
-    vec3 lin = vec3(srgb_to_linear(c.r), srgb_to_linear(c.g), srgb_to_linear(c.b));
+    vec3 lin = vec3(srgbToLinear(c.r), srgbToLinear(c.g), srgbToLinear(c.b));
 
-    float count = uStrength * 200.0;
-    float blob_radius = 2.0;
-    float brightness_add = 0.0;
+    // 現フラグメントの整数ピクセル座標（CPU の px, py に対応）
+    ivec2 p = ivec2(floor(vTexCoord * uResolution));
 
-    vec2 px = vTexCoord * uResolution;
-
-    for (int i = 0; i < 200; i++) {
-        if (float(i) >= count) break;
+    const int BLOB_RADIUS = 2;
+    for (int i = 0; i < uCount; i++) {
         uint ui = uint(i);
-        // uSeed * 1000u: 各光点のハッシュ入力を seed でシフトする定数倍。
-        // uint 演算なのでラップアラウンド（オーバーフロー）は意図的な動作。
-        uint h1 = hash_uint(ui + uSeed * 1000u);
-        uint h2 = hash_uint(ui + uSeed * 1000u + 7654u);
-        uint h3 = hash_uint(ui + uSeed * 1000u + 9876u);
-        float fx = hash_to_float(h1) * uResolution.x;
-        float fy = hash_to_float(h2) * uResolution.y;
-        float dist = length(px - vec2(fx, fy));
-        if (dist <= blob_radius) {
-            brightness_add += 0.5 + hash_to_float(h3) * 0.5;
+        float fx = hash01(3u * ui);
+        float fy = hash01(3u * ui + 1u);
+        float fb = hash01(3u * ui + 2u);
+        int cx = int(fx * uResolution.x);
+        int cy = int(fy * uResolution.y);
+        float brightness = 0.5 + fb * 0.5;
+        if (abs(p.x - cx) <= BLOB_RADIUS && abs(p.y - cy) <= BLOB_RADIUS) {
+            // CPU と同じく点ごとに min(1.0) でクランプ
+            lin = min(lin + vec3(brightness), 1.0);
         }
     }
 
-    vec3 result = clamp(lin + vec3(brightness_add), 0.0, 1.0);
-    fragColor = vec4(linear_to_srgb(result.r), linear_to_srgb(result.g), linear_to_srgb(result.b), c.a);
+    fragColor = vec4(linearToSrgb(lin.r), linearToSrgb(lin.g), linearToSrgb(lin.b), c.a);
 }

--- a/crates/core/src/shaders/floaters.frag
+++ b/crates/core/src/shaders/floaters.frag
@@ -12,6 +12,14 @@ precision mediump float;
 // 注意: GPU 版はブレンドを sRGB 空間で直接行う（linear 変換なし）。
 // CPU 実装は linear sRGB 空間で乗算するため、厳密な色値は異なるが
 // 視覚的な近似として許容している（「GPU 版は近似」はこの差異を指す）。
+//
+// #134（parity 未達・別追跡）: flickering_stars は 32bit spatial hash で CPU↔GLSL を
+// 統一済みだが、floaters は (1) 乱歩ストランドが「データ依存の RNG ストリーム」を
+// 逐次消費し、(2) 最終マスクに 3×3 box blur を掛けるため、単一パスでの忠実再現は
+// 200 点ぶんのストランドを毎フラグメントで replay しつつ 9 近傍のマスクを再計算する
+// 必要があり、実機（Flutter）描画として非現実的。本シェーダは意図的な近似のまま据え置く。
+// 真の parity には「ストランド廃止の blob-only モデルに CPU/GLSL 双方を寄せる」か
+// 「CPU 生成マスクをテクスチャとして渡す」かの設計判断が必要（freeza で起票・追跡）。
 
 uniform sampler2D uTexture;
 uniform float uStrength;

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -1783,12 +1783,13 @@ pub enum DepthBlurKind {
 ///
 /// 深度ブラーは深度マップという第 2 入力を要するため、単一入力契約の
 /// [`crate::Filter`] / [`crate::apply`] には載せていない（`Filter` は `Copy` で、
-/// 画像を抱える深度マップを variant に入れられない）。consumer は次の 2 経路で到達する:
-/// - Rust ライブラリ: 本関数 `depth_aware_blur` を直接呼ぶ（既に `pub`）。
-/// - GLSL（universal-experience の Flutter 経路）: [`crate::shaders::depth_aware_blur_glsl`]
-///   + [`crate::shaders::depth_aware_blur_uniforms`]。深度マップを `uDepth` テクスチャで渡す。
-///   CPU は 8 ビン box blur の多パス、GLSL は per-fragment Fibonacci 16 tap disk と算法が
-///   異なるため bit/PSNR 等価ではなく、効果（ピント面鮮明・離れるほどぼける・kind 選択）で担保。
+/// 画像を抱える深度マップを variant に入れられない）。consumer の到達経路は 2 つ:
+/// Rust ライブラリは本関数 `depth_aware_blur` を直接呼ぶ（既に `pub`）。
+/// GLSL（universal-experience の Flutter 経路）は [`crate::shaders::depth_aware_blur_glsl`]
+/// + [`crate::shaders::depth_aware_blur_uniforms`] を使い、深度マップを `uDepth` テクスチャで渡す。
+///
+/// CPU は 8 ビン box blur の多パス、GLSL は per-fragment Fibonacci 16 tap disk と算法が
+/// 異なるため bit/PSNR 等価ではなく、効果（ピント面鮮明・離れるほどぼける・kind 選択）で担保する。
 pub fn depth_aware_blur(
     img: DynamicImage,
     depth_map: &DynamicImage,
@@ -2780,6 +2781,23 @@ pub fn teichopsia(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
 // Issue #59: Flickering Stars フィルタ
 // ---------------------------------------------------------------
 
+/// 点群（flickering_stars / floaters）用の 32bit spatial hash（#134）。
+///
+/// draw index `k` と `seed` から決定論的に 0..=u32::MAX を返す。#99/#125 の
+/// cataract grid_hash と同じ黄金比定数混合 + XOR-shift finalizer 系列で、GLSL の
+/// `uint` 演算（mod 2^32 wrap）と bit 一致する。64bit LCG と違い 32bit GPU で再現可能。
+pub(crate) fn star_hash32(seed: u32, k: u32) -> u32 {
+    let mut h = seed
+        .wrapping_mul(0x9e3779b9)
+        .wrapping_add(k.wrapping_mul(0x85ebca6b));
+    h ^= h >> 15;
+    h = h.wrapping_mul(0x2c1b3c6d);
+    h ^= h >> 12;
+    h = h.wrapping_mul(0x297a2d39);
+    h ^= h >> 15;
+    h
+}
+
 /// 閃光光点（Flickering Stars）シミュレーション。
 ///
 /// LCG でランダムな光点を生成して additive blend する。
@@ -2803,28 +2821,24 @@ pub fn flickering_stars(img: DynamicImage, strength: f32, seed: u64) -> Result<D
     let w_f = width as f32;
     let h_f = height as f32;
 
-    // LCG ヘルパー
-    let lcg_next = |state: u64| -> (u64, f32) {
-        let next = state
-            .wrapping_mul(6364136223846793005)
-            .wrapping_add(1442695040888963407);
-        let fval = (next >> 32) as f32 / u32::MAX as f32;
-        (next, fval)
-    };
-
-    let mut state = seed.wrapping_mul(0x9e3779b97f4a7c15).wrapping_add(1);
+    // #134: 32bit spatial hash で点ごとの位置・輝度を生成する。
+    // 旧 64bit LCG（`(state>>32)` 抽出）は GLSL の 32bit uint で再現できず CPU↔GLSL が
+    // 乖離していた。点 i は draw index 3i, 3i+1, 3i+2 を引く（順序固定）。
+    // `flickering_stars.frag` / sim_flickering_stars_glsl と bit 一致する。
+    let seed32 = seed as u32;
+    let hash01 = |k: u32| -> f32 { star_hash32(seed32, k) as f32 / u32::MAX as f32 };
 
     // linear sRGB に変換して作業
     let (mut linear, alpha) = rgba_to_linear_planes(&rgba);
 
     const BLOB_RADIUS: i32 = 2;
 
-    for _ in 0..count {
-        let (s1, fx) = lcg_next(state);
-        let (s2, fy) = lcg_next(s1);
+    for i in 0..count {
+        let i = i as u32;
+        let fx = hash01(3 * i);
+        let fy = hash01(3 * i + 1);
         // 輝度 0.5..1.0（白っぽい光点）
-        let (s3, fb) = lcg_next(s2);
-        state = s3;
+        let fb = hash01(3 * i + 2);
 
         let cx = (fx * w_f) as i32;
         let cy = (fy * h_f) as i32;

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -4199,3 +4199,93 @@ fn depth_aware_blur_glsl_larger_distance_blurs_more() {
         "farther-from-focus depth must blur at least as much"
     );
 }
+
+// ===========================================================================
+// #134: flickering_stars CPU↔GLSL 等価（32bit spatial hash 統一）
+// ===========================================================================
+
+/// CPU vision::star_hash32 と同一の 32bit hash（flickering_stars.frag と bit 一致）。
+fn star_hash32(seed: u32, k: u32) -> u32 {
+    let mut h = seed
+        .wrapping_mul(0x9e3779b9)
+        .wrapping_add(k.wrapping_mul(0x85ebca6b));
+    h ^= h >> 15;
+    h = h.wrapping_mul(0x2c1b3c6d);
+    h ^= h >> 12;
+    h = h.wrapping_mul(0x297a2d39);
+    h ^= h >> 15;
+    h
+}
+
+/// flickering_stars.frag の忠実ミラー。
+fn sim_flickering_stars_glsl(img: &RgbaImage, strength: f32, seed: u32) -> RgbaImage {
+    let (w, h) = img.dimensions();
+    let count = (strength.clamp(0.0, 1.0) * 200.0) as usize;
+    let hash01 = |k: u32| -> f32 { star_hash32(seed, k) as f32 / u32::MAX as f32 };
+    const BLOB_RADIUS: i32 = 2;
+
+    let mut out = img.clone();
+    for y in 0..h {
+        for x in 0..w {
+            let px = img.get_pixel(x, y);
+            let mut lin = [
+                srgb_to_linear(px[0] as f32 / 255.0),
+                srgb_to_linear(px[1] as f32 / 255.0),
+                srgb_to_linear(px[2] as f32 / 255.0),
+            ];
+            for i in 0..count as u32 {
+                let fx = hash01(3 * i);
+                let fy = hash01(3 * i + 1);
+                let fb = hash01(3 * i + 2);
+                let cx = (fx * w as f32) as i32;
+                let cy = (fy * h as f32) as i32;
+                let brightness = 0.5 + fb * 0.5;
+                if (x as i32 - cx).abs() <= BLOB_RADIUS && (y as i32 - cy).abs() <= BLOB_RADIUS {
+                    lin[0] = (lin[0] + brightness).min(1.0);
+                    lin[1] = (lin[1] + brightness).min(1.0);
+                    lin[2] = (lin[2] + brightness).min(1.0);
+                }
+            }
+            out.put_pixel(
+                x,
+                y,
+                image::Rgba([
+                    (linear_to_srgb(lin[0]) * 255.0).round() as u8,
+                    (linear_to_srgb(lin[1]) * 255.0).round() as u8,
+                    (linear_to_srgb(lin[2]) * 255.0).round() as u8,
+                    px[3],
+                ]),
+            );
+        }
+    }
+    out
+}
+
+#[test]
+fn shader_equiv_flickering_stars_strength_1_0() {
+    use sensus_core::vision::flickering_stars;
+    let img = gradient_32();
+    let cpu = flickering_stars(img.clone(), 1.0, 42).unwrap().to_rgba8();
+    let gpu = sim_flickering_stars_glsl(&img.to_rgba8(), 1.0, 42);
+    let db = psnr(&cpu, &gpu);
+    assert!(db >= 40.0, "flickering_stars strength=1.0: CPU↔GLSL PSNR {db:.1} dB < 40 dB");
+}
+
+#[test]
+fn shader_equiv_flickering_stars_strength_0_5_non_square() {
+    use sensus_core::vision::flickering_stars;
+    let img = gradient_64x32();
+    let cpu = flickering_stars(img.clone(), 0.5, 7).unwrap().to_rgba8();
+    let gpu = sim_flickering_stars_glsl(&img.to_rgba8(), 0.5, 7);
+    let db = psnr(&cpu, &gpu);
+    assert!(db >= 40.0, "flickering_stars 0.5 64x32: CPU↔GLSL PSNR {db:.1} dB < 40 dB");
+}
+
+#[test]
+fn shader_equiv_flickering_stars_seed_differs() {
+    use sensus_core::vision::flickering_stars;
+    let img = gradient_32();
+    let a = flickering_stars(img.clone(), 1.0, 1).unwrap().to_rgba8();
+    let b = flickering_stars(img.clone(), 1.0, 999).unwrap().to_rgba8();
+    assert!(psnr(&a, &b) < 60.0, "flickering_stars: 異なる seed で同一出力（seed 不使用の疑い）");
+}


### PR DESCRIPTION
## 概要
P1 #134。floaters / flickering_stars の CPU↔GLSL hash 乖離を解消する。

## flickering_stars（統一完了）
- CPU の 64bit LCG（`(state>>32)` 抽出は 32bit GPU で再現不能）→ 点 index ベースの 32bit spatial hash `vision::star_hash32`（#99/#125 cataract と同系列の黄金比混合 + XOR-shift）に統一。
- `flickering_stars.frag` を旧 Wang hash + 円形 distance + 合計後クランプ → 同一 hash + 整数ピクセル中心 5×5 正方ボックス + **点ごとの min(1.0) クランプ**（CPU と同順・同演算）に書き換え。
- 点数は float 再計算の不一致を避けるため `FlickeringStarsUniforms.count`（`(strength*200) as i32`）で渡す。
- `sim_flickering_stars_glsl` 忠実ミラーで **CPU↔GLSL PSNR ≥ 40 dB**（strength 1.0 / 0.5 非正方形 / seed 差）。

## floaters（parity 不能を明文化 → #141 に分離）
単一パス GLSL での忠実再現は非現実的:
1. 乱歩ストランドが**データ依存の RNG ストリーム**を逐次消費 → フラグメントで先頭から replay 必須。
2. 最終マスクに **3×3 box blur** → 9 近傍でマスク全体を再計算必須。
200 点 × ステップ円盤 × 9 タップ/フラグメントは実機描画に非現実的。真の parity には設計判断（blob-only 統一 or CPU マスクのテクスチャ受け渡し）が必要なため **#141 に分離**。`floaters.frag` は意図的近似のまま、理由をヘッダに明記。

## テスト
- core 283 / shader_equivalence 145（+3 flickering）/ 全 workspace green、clippy クリーン

refs #134, #141