### PR TITLE
fix: #109 depth-blur のマジック定数 0.023 を名前付き定数化して文書化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **fix: kako-jun/sensus#109 depth-blur のマジック定数 0.023 を名前付き定数化して文書化**: depth フィルタ（myopia-depth / hyperopia-depth / depth-of-field）の CLI が `cli.strength * 0.023` という未文書化のマジック数で半径を算出していた。`DEPTH_BLUR_MAX_RADIUS_RATIO`（= 0.023、非深度の近視ディスクブラー `MYOPIA_MAX_RADIUS_RATIO` と同値・Smith–Helmholtz の近視最大相当）として名前付き定数化し、`--strength 1.0` がこの比＝**全効果（上限）**であることを doc で明記（縮小ではない）。3 箇所（mpo / portrait / depth）を定数参照に統一。
+
 - **docs: kako-jun/sensus#115 CHANGELOG の架空 hearing 名 / overview APD 番号 / noise_induced 帯域幅の doc 不一致を修正**: (1) v0.2.0 節の hearing フィルタ一覧が架空名（`sudden_deafness`/`presbycusis`/`recruitment`/`temporary_threshold_shift`/`noise_induced_loss`）で「10」と誤記 → 実関数名 11 個に訂正。(2) overview.md の APD セクション見出しを Issue #38 → **#37**（#38 は floaters）。(3) `noise_induced_hearing_loss` の doc コメント「±1 kHz / 帯域幅 2000」を実装（`50 + s*950` Hz、最大 1000 Hz）に合わせて訂正。
 
 - **fix: kako-jun/sensus#117 sensus-core 単体テストが jpeg feature 不足でビルド不能だったのを修正**: `stereo.rs` のテストが `image::codecs::jpeg::JpegEncoder` を使うが core の依存は `png` feature のみで、`cargo test -p sensus-core` / `cargo clippy --all-targets`（core 単体）が pre-existing で落ちていた。workspace test は cli の image default-features による feature unification で隠れていた。core の **dev-dependencies に `image` の `jpeg` feature** を追加（本体依存は png のみ維持）。CI に `cargo test -p sensus-core` 単体ステップを追加して回帰防止。

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,6 +12,15 @@ use thiserror::Error;
 
 mod audio;
 
+/// depth フィルタ（myopia-depth / hyperopia-depth / depth-of-field）の `--strength 1.0`
+/// に対応する最大ぼけ半径（min(W,H) 比）。
+///
+/// この値は非深度の近視ディスクブラー（`vision::myopia` の `MYOPIA_MAX_RADIUS_RATIO`）と
+/// 同じ 0.023 で、Smith–Helmholtz の `0.5 × pupil_diameter × |D|` から導かれる「近視最大相当」。
+/// `depth_aware_blur` は各画素のぼけ半径を `depth との差 × この比 × min(W,H)` で算出するため、
+/// `--strength 1.0` がこの比＝**全効果**になる（縮小ではなく、これが上限）。
+const DEPTH_BLUR_MAX_RADIUS_RATIO: f32 = 0.023;
+
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum Filter {
     // Phase 1: 色覚特性 (Issue #2)
@@ -516,7 +525,7 @@ fn run(cli: Cli) -> Result<(), RunError> {
             .map_err(|e| RunError::MpoError(format!("sensus: {e}")))?;
         let depth_img = stereo_to_depth(&left, &right)
             .map_err(|e| RunError::MpoError(format!("sensus: {e}")))?;
-        let out = depth_aware_blur(left, &depth_img, cli.focus, cli.strength * 0.023, kind)
+        let out = depth_aware_blur(left, &depth_img, cli.focus, cli.strength * DEPTH_BLUR_MAX_RADIUS_RATIO, kind)
             .map_err(|e| RunError::Pipeline(format!("sensus: {e}")))?;
         let out_path = cli.output.as_ref().unwrap();
         return out.save(out_path).map_err(|source| RunError::OutputSave {
@@ -564,7 +573,7 @@ fn run(cli: Cli) -> Result<(), RunError> {
         };
 
         let kind = cli.filter[0].depth_kind().unwrap();
-        let out = depth_aware_blur(source_img, &depth_map, cli.focus, cli.strength * 0.023, kind)
+        let out = depth_aware_blur(source_img, &depth_map, cli.focus, cli.strength * DEPTH_BLUR_MAX_RADIUS_RATIO, kind)
             .map_err(|e| RunError::PortraitError(format!("sensus: {e}")))?;
         let out_path = cli.output.as_ref().unwrap();
         return out.save(out_path).map_err(|source| RunError::OutputSave {
@@ -606,7 +615,7 @@ fn run(cli: Cli) -> Result<(), RunError> {
             path: depth_path.clone(),
             source,
         })?;
-        let out = depth_aware_blur(img, &depth_img, cli.focus, cli.strength * 0.023, kind)
+        let out = depth_aware_blur(img, &depth_img, cli.focus, cli.strength * DEPTH_BLUR_MAX_RADIUS_RATIO, kind)
             .map_err(|e| RunError::Pipeline(format!("sensus: {e}")))?;
         let out_path = cli.output.as_ref().unwrap();
         return out.save(out_path).map_err(|source| RunError::OutputSave {


### PR DESCRIPTION
## 概要
depth フィルタ（myopia-depth / hyperopia-depth / depth-of-field）の CLI が `cli.strength * 0.023` という**未文書化のマジック数**で最大ぼけ半径を算出しており、`--strength 1.0` が「全効果」に見えない懸念があった（監査 #109）。

## 変更
`DEPTH_BLUR_MAX_RADIUS_RATIO`（= 0.023）として名前付き定数化し、3 箇所（mpo / portrait / depth）を参照に統一。doc コメントで:
- この値は非深度の近視ディスクブラー `MYOPIA_MAX_RADIUS_RATIO` と同じ 0.023 で、Smith–Helmholtz の近視最大相当
- `depth_aware_blur` は半径を `depth との差 × 比 × min(W,H)` で算出するため、`--strength 1.0` がこの比＝**全効果（上限）**である（縮小ではない）

ことを明記。挙動は不変（定数化と文書化のみ）。`cargo clippy -p sensus --all-targets` 0 warnings。

closes #109