### PR TITLE
fix: #110 Filter::Floaters.size の死にフィールドを配線

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **fix: kako-jun/sensus#110 `Filter::Floaters.size` の死にフィールドを配線（受け取って捨てていた）**: `apply()` が `let _ = size` で無視し「現在は無視（0.0 を渡すこと）」と doc されていた死にフィールドを、blob 半径・糸くず幅の相対倍率として機能させた。`vision::floaters` / `floaters_mask` に `size` 引数を追加（0.1..=5.0 に clamp、0/NaN は 1.0 フォールバック）、`blob_radius` と strand `half_w` に乗じる。`apply()` / `Pipeline::FilterStep` から enum の `size` を渡すよう配線。マスクは CPU 生成（#134 方針 B）なので GLSL 側変更は不要。効果アサート `floaters_size_scales_coverage`（size 大 → 被覆面積増＝平均マスク低下、NaN→1.0 フォールバック）。
+
 ### Tests / Findings
 
 - **test: kako-jun/sensus#114 hearing 効果アサートテストを網羅追加**: 従来は strength=0 恒等 / 空 / パニック耐性のみで「実際に効いているか」の効果検証が薄かった。6 件追加 — `diplacusis_left_and_right_differ`（L≠R = 左右別音程）/ `sudden_hearing_loss_attenuates_notch_band`（ノッチ帯域の RMS 低下）/ `noise_induced_hearing_loss_attenuates_4khz_more_than_low`（4 kHz を 500 Hz より強く減衰）/ `pitch_shift_changes_signal_but_keeps_length`（波形変化＋長さ保持）/ `tinnitus_adds_tone_on_nonsilent_signal`（無音だけでなく信号入りにもトーン重畳）/ `audio_pipeline_matches_sequential_apply_hearing`（AudioPipeline = 逐次 apply_hearing と bit 一致）。

--- a/crates/core/benches/filters.rs
+++ b/crates/core/benches/filters.rs
@@ -42,7 +42,7 @@ fn bench_filters(c: &mut Criterion) {
 
     // floaters
     c.bench_function("floaters_512", |b| {
-        b.iter(|| vision::floaters(img_512.clone(), 1.0, 0.5, 0, 0.5, 0.5).unwrap())
+        b.iter(|| vision::floaters(img_512.clone(), 1.0, 0.5, 0, 0.5, 0.5, 1.0).unwrap())
     });
 
     // eye_strain / dry_eye

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -55,9 +55,9 @@ pub enum Filter {
     TunnelVision,
     // vision (Phase 3: light / transparency)
     Cataract,
-    /// 飛蚊症。`seed`: ランダムシード, `density`: blob 密度, `size`: blob 相対サイズ係数
+    /// 飛蚊症。`seed`: ランダムシード, `density`: blob 密度, `size`: blob 半径・糸くず幅の相対倍率
     ///
-    /// `size`: 将来の blob_radius_ratio に使用予定。現在は無視される（0.0 を渡すこと）。
+    /// `size`: 1.0 = 既定。`vision::floaters` の blob 半径・糸くず幅に乗じる（0.1..=5.0 に clamp、#110）。
     Floaters { seed: u64, density: f32, size: f32 },
     Photophobia,
     NightBlindness,
@@ -110,9 +110,7 @@ pub fn apply(
         Filter::Photophobia => vision::photophobia(img, strength),
         Filter::NightBlindness => vision::nyctalopia(img, strength),
         Filter::Floaters { seed, density, size } => {
-            // size は blob サイズ係数として gaze_x/gaze_y の中央値と組み合わせる
-            let _ = size; // size フィールドは将来の blob_radius_ratio に使用予定; 現在は無視
-            vision::floaters(img, strength, density, seed, 0.5, 0.5)
+            vision::floaters(img, strength, density, seed, 0.5, 0.5, size)
         }
         Filter::Glaucoma { mode } => vision::glaucoma(img, strength, mode),
         Filter::MacularDegeneration => vision::macular_degeneration(img, strength),

--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -80,8 +80,8 @@ impl FilterStep {
         match self.filter {
             Filter::Astigmatism { axis_deg } => vision::astigmatism(img, self.strength, axis_deg),
             Filter::Cataract => vision::cataract(img, self.strength, self.seed),
-            Filter::Floaters { seed, density, .. } => {
-                vision::floaters(img, self.strength, density, seed, self.gaze_x, self.gaze_y)
+            Filter::Floaters { seed, density, size } => {
+                vision::floaters(img, self.strength, density, seed, self.gaze_x, self.gaze_y, size)
             }
             Filter::Photophobia => vision::photophobia(img, self.strength),
             Filter::NightBlindness => vision::nyctalopia(img, self.strength),

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -938,6 +938,7 @@ pub fn floaters_mask(
     seed: u64,
     gaze_x: f32,
     gaze_y: f32,
+    size: f32,
 ) -> image::GrayImage {
     let w_f = width as f32;
     let h_f = height as f32;
@@ -945,6 +946,8 @@ pub fn floaters_mask(
     let density = density.clamp(0.0, 1.0);
     let gaze_x = gaze_x.clamp(0.0, 1.0);
     let gaze_y = gaze_y.clamp(0.0, 1.0);
+    // size は blob 半径・糸くず幅の相対倍率（#110）。1.0 = 既定。0 や NaN は 1.0 にフォールバック。
+    let size = if size.is_finite() && size > 0.0 { size.clamp(0.1, 5.0) } else { 1.0 };
 
     // 視線オフセット（フローターは視線に追随）
     let offset_x = (gaze_x - 0.5) * 0.3 * w_f;
@@ -960,7 +963,7 @@ pub fn floaters_mask(
     let blob_count = (total_count as f32 * 0.3).ceil() as usize; // 30% 円形
     let strand_count = total_count - blob_count;                  // 70% 糸くず
 
-    let blob_radius = (w_f.min(h_f) * 0.04).max(2.0);
+    let blob_radius = (w_f.min(h_f) * 0.04 * size).max(2.0);
     let blob_radius_sq = blob_radius * blob_radius;
 
     // ── LCG ヘルパー ──────────────────────────────────────────────
@@ -1028,7 +1031,7 @@ pub fn floaters_mask(
         let sx = fx * w_f + offset_x;
         let sy = fy * h_f + offset_y;
         let n_seg = (fn_seg * 4.0) as usize + 2; // 2..=5
-        let half_w = (f_width * 3.0 + 1.0) * 0.5; // 0.5..=2.0
+        let half_w = (f_width * 3.0 + 1.0) * 0.5 * size; // 0.5..=2.0（size 倍率、#110）
 
         let mut cur_x = sx;
         let mut cur_y = sy;
@@ -1131,6 +1134,7 @@ pub fn floaters_mask(
 /// - `seed`: blob 配置のランダムシード（実際に使用される）
 /// - `gaze_x`: 視線 X 位置 (0.0 = 左, 1.0 = 右)
 /// - `gaze_y`: 視線 Y 位置 (0.0 = 上, 1.0 = 下)
+/// - `size`: blob 半径・糸くず幅の相対倍率（#110、1.0 = 既定、0.1..=5.0 に clamp）
 pub fn floaters(
     img: DynamicImage,
     strength: f32,
@@ -1138,6 +1142,7 @@ pub fn floaters(
     seed: u64,
     gaze_x: f32,
     gaze_y: f32,
+    size: f32,
 ) -> crate::Result<DynamicImage> {
     let strength = normalize_strength(strength);
     let mut rgba = img.to_rgba8();
@@ -1148,7 +1153,7 @@ pub fn floaters(
 
     let width = rgba.width();
     let height = rgba.height();
-    let mask = floaters_mask(width, height, density, seed, gaze_x, gaze_y);
+    let mask = floaters_mask(width, height, density, seed, gaze_x, gaze_y, size);
 
     for y in 0..height {
         for x in 0..width {
@@ -4090,11 +4095,32 @@ mod tests {
     }
 
     #[test]
+    fn floaters_size_scales_coverage() {
+        // #110: size を大きくすると blob/糸くずが太くなり、マスクの被覆面積が増える
+        // （= 平均マスク値が下がる）。同一 seed/density で比較する。
+        let mean = |m: &image::GrayImage| {
+            m.as_raw().iter().map(|&v| v as u32).sum::<u32>() as f32 / m.as_raw().len() as f32
+        };
+        let small = floaters_mask(64, 64, 0.5, 42, 0.5, 0.5, 0.5);
+        let large = floaters_mask(64, 64, 0.5, 42, 0.5, 0.5, 2.0);
+        assert!(
+            mean(&large) < mean(&small),
+            "larger size must increase floater coverage: mean(large)={}, mean(small)={}",
+            mean(&large),
+            mean(&small)
+        );
+        // size は 1.0 が既定（恒等的に効かないわけではないが、0/NaN は 1.0 フォールバック）
+        let nan = floaters_mask(64, 64, 0.5, 42, 0.5, 0.5, f32::NAN);
+        let one = floaters_mask(64, 64, 0.5, 42, 0.5, 0.5, 1.0);
+        assert_eq!(nan.as_raw(), one.as_raw(), "NaN size must fall back to 1.0");
+    }
+
+    #[test]
     fn floaters_strength_zero_is_identity() {
         let input = solid_rgba(16, 16, [200, 100, 50, 255]);
         let original = raw_rgba_vec(&input);
         assert_eq!(
-            raw_rgba_vec(&floaters(input, 0.0, 0.5, 42, 0.5, 0.5).unwrap()),
+            raw_rgba_vec(&floaters(input, 0.0, 0.5, 42, 0.5, 0.5, 1.0).unwrap()),
             original
         );
     }
@@ -4154,7 +4180,7 @@ mod tests {
         let original = raw_rgba_vec(&input);
         // density=0.0 なので blob_count=0 → early return で identity
         assert_eq!(
-            raw_rgba_vec(&floaters(input, 1.0, 0.0, 42, 0.5, 0.5).unwrap()),
+            raw_rgba_vec(&floaters(input, 1.0, 0.0, 42, 0.5, 0.5, 1.0).unwrap()),
             original
         );
     }
@@ -4174,7 +4200,7 @@ mod tests {
         check_alpha(&cataract(input.clone(), 1.0, 42).unwrap());
         check_alpha(&photophobia(input.clone(), 1.0).unwrap());
         check_alpha(&nyctalopia(input.clone(), 1.0).unwrap());
-        check_alpha(&floaters(input, 1.0, 0.5, 42, 0.5, 0.5).unwrap());
+        check_alpha(&floaters(input, 1.0, 0.5, 42, 0.5, 0.5, 1.0).unwrap());
     }
 
     // ---------------------------------------------------------------
@@ -4190,7 +4216,7 @@ mod tests {
         check_dims(&cataract(input.clone(), 1.0, 42).unwrap());
         check_dims(&photophobia(input.clone(), 1.0).unwrap());
         check_dims(&nyctalopia(input.clone(), 1.0).unwrap());
-        check_dims(&floaters(input, 1.0, 0.5, 42, 0.5, 0.5).unwrap());
+        check_dims(&floaters(input, 1.0, 0.5, 42, 0.5, 0.5, 1.0).unwrap());
     }
 
     // ---------------------------------------------------------------
@@ -4251,8 +4277,8 @@ mod tests {
     #[test]
     fn floaters_same_seed_is_reproducible() {
         let input = solid_rgba(32, 32, [200, 150, 100, 255]);
-        let out1 = raw_rgba_vec(&floaters(input.clone(), 0.8, 0.3, 12345, 0.5, 0.5).unwrap());
-        let out2 = raw_rgba_vec(&floaters(input, 0.8, 0.3, 12345, 0.5, 0.5).unwrap());
+        let out1 = raw_rgba_vec(&floaters(input.clone(), 0.8, 0.3, 12345, 0.5, 0.5, 1.0).unwrap());
+        let out2 = raw_rgba_vec(&floaters(input, 0.8, 0.3, 12345, 0.5, 0.5, 1.0).unwrap());
         assert_eq!(out1, out2, "same seed must produce byte-exact identical output");
     }
 
@@ -4263,8 +4289,8 @@ mod tests {
     #[test]
     fn floaters_different_seed_differs() {
         let input = solid_rgba(32, 32, [200, 150, 100, 255]);
-        let out1 = raw_rgba_vec(&floaters(input.clone(), 0.8, 0.5, 111, 0.5, 0.5).unwrap());
-        let out2 = raw_rgba_vec(&floaters(input, 0.8, 0.5, 999, 0.5, 0.5).unwrap());
+        let out1 = raw_rgba_vec(&floaters(input.clone(), 0.8, 0.5, 111, 0.5, 0.5, 1.0).unwrap());
+        let out2 = raw_rgba_vec(&floaters(input, 0.8, 0.5, 999, 0.5, 0.5, 1.0).unwrap());
         assert_ne!(out1, out2, "different seeds must produce different output");
     }
 
@@ -4293,7 +4319,7 @@ mod tests {
     #[test]
     fn floaters_1x1_does_not_panic() {
         let input = pixel(128, 64, 32, 255);
-        let _ = floaters(input, 1.0, 0.5, 42, 0.5, 0.5).unwrap();
+        let _ = floaters(input, 1.0, 0.5, 42, 0.5, 0.5, 1.0).unwrap();
     }
 
     // ---------------------------------------------------------------
@@ -4419,8 +4445,8 @@ mod tests {
     #[test]
     fn floaters_seed_0_ne_seed_1() {
         let input = solid_rgba(32, 32, [200, 150, 100, 255]);
-        let out0 = raw_rgba_vec(&floaters(input.clone(), 0.8, 0.5, 0, 0.5, 0.5).unwrap());
-        let out1 = raw_rgba_vec(&floaters(input, 0.8, 0.5, 1, 0.5, 0.5).unwrap());
+        let out0 = raw_rgba_vec(&floaters(input.clone(), 0.8, 0.5, 0, 0.5, 0.5, 1.0).unwrap());
+        let out1 = raw_rgba_vec(&floaters(input, 0.8, 0.5, 1, 0.5, 0.5, 1.0).unwrap());
         assert_ne!(out0, out1, "seed=0 and seed=1 must produce different output");
     }
 

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -4339,8 +4339,8 @@ fn sim_floaters_glsl(img: &RgbaImage, mask: &image::GrayImage, strength: f32) ->
 fn shader_equiv_floaters_mask_blend_strength_1_0() {
     use sensus_core::vision::{floaters, floaters_mask};
     let img = gradient_32();
-    let mask = floaters_mask(32, 32, 0.8, 42, 0.5, 0.5);
-    let cpu = floaters(img.clone(), 1.0, 0.8, 42, 0.5, 0.5).unwrap().to_rgba8();
+    let mask = floaters_mask(32, 32, 0.8, 42, 0.5, 0.5, 1.0);
+    let cpu = floaters(img.clone(), 1.0, 0.8, 42, 0.5, 0.5, 1.0).unwrap().to_rgba8();
     let gpu = sim_floaters_glsl(&img.to_rgba8(), &mask, 1.0);
     let db = psnr(&cpu, &gpu);
     // 同一 u8 マスク・同一ブレンドなので bit 一致（PSNR=∞）。安全側で 50 dB。
@@ -4352,8 +4352,8 @@ fn shader_equiv_floaters_mask_blend_strength_0_5_non_square() {
     use sensus_core::vision::{floaters, floaters_mask};
     let img = gradient_64x32();
     let (w, h) = (img.width(), img.height());
-    let mask = floaters_mask(w, h, 0.6, 7, 0.5, 0.5);
-    let cpu = floaters(img.clone(), 0.5, 0.6, 7, 0.5, 0.5).unwrap().to_rgba8();
+    let mask = floaters_mask(w, h, 0.6, 7, 0.5, 0.5, 1.0);
+    let cpu = floaters(img.clone(), 0.5, 0.6, 7, 0.5, 0.5, 1.0).unwrap().to_rgba8();
     let gpu = sim_floaters_glsl(&img.to_rgba8(), &mask, 0.5);
     let db = psnr(&cpu, &gpu);
     assert!(db >= 50.0, "floaters 0.5 64x32: CPU↔GLSL PSNR {db:.1} dB < 50 dB");
@@ -4363,11 +4363,11 @@ fn shader_equiv_floaters_mask_blend_strength_0_5_non_square() {
 fn floaters_mask_is_strength_independent() {
     // マスクは density/seed/gaze だけで決まり strength に依存しない（方針 B の前提）。
     use sensus_core::vision::floaters_mask;
-    let a = floaters_mask(32, 32, 0.8, 42, 0.5, 0.5);
-    let b = floaters_mask(32, 32, 0.8, 42, 0.5, 0.5);
+    let a = floaters_mask(32, 32, 0.8, 42, 0.5, 0.5, 1.0);
+    let b = floaters_mask(32, 32, 0.8, 42, 0.5, 0.5, 1.0);
     assert_eq!(a.as_raw(), b.as_raw(), "floaters_mask must be deterministic");
     // density 0 は全面透明（255）
-    let empty = floaters_mask(32, 32, 0.0, 42, 0.5, 0.5);
+    let empty = floaters_mask(32, 32, 0.0, 42, 0.5, 0.5, 1.0);
     assert!(empty.as_raw().iter().all(|&v| v == 255), "density 0 → all transparent");
     // フローターがあれば 255 未満の画素が存在する
     assert!(a.as_raw().iter().any(|&v| v < 255), "mask must contain floater pixels");


### PR DESCRIPTION
## 概要
`Filter::Floaters.size` は `apply()` で `let _ = size` と**受け取って捨てられ**、doc も「現在は無視（0.0 を渡すこと）」だった死にフィールド（監査 #110）。floaters がマスク化（#134 方針 B）したことで CPU 内に閉じて配線できるようになったため、**blob 半径・糸くず幅の相対倍率**として機能させた。

## 変更
- `vision::floaters` / `vision::floaters_mask` に `size: f32` 引数を追加（0.1..=5.0 に clamp、0/NaN は 1.0 フォールバック）。`blob_radius` と strand `half_w` に乗じる。
- `lib.rs apply()` / `pipeline.rs FilterStep::apply` から enum の `size` を渡すよう配線。enum doc を実態に更新。
- マスクは CPU 生成なので **GLSL（floaters.frag）側の変更は不要**。

## テスト
- `floaters_size_scales_coverage`: size 大 → 被覆面積増（平均マスク低下）/ NaN→1.0 フォールバック
- 既存 floaters テスト（恒等・density0・再現性・等価）green、core 292、clippy 0

closes #110