### PR TITLE
fix: #111 死にコードの NotImplemented/exit-2 経路を削除 + dry_eye seed doc 是正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **fix: kako-jun/sensus#111 死にコードの `Error::NotImplemented` / exit-2 経路を削除し、dry_eye の seed doc を是正**: 全 `Filter` バリアントは実装済みで `apply()` の match は網羅的（新バリアント追加は未実装ならコンパイルエラー）なため、`Error::NotImplemented` は core から二度と返らず、CLI の exit-2 ハンドラは到達不能な死にコードだった。さらに `--pipe` 経路ではこの経路が `RunError::Pipeline`（exit 1）に誤マップされ、文書化された exit-2 契約と矛盾していた。`Error::NotImplemented` / `RunError::NotImplemented` / 両ハンドラ / 旧 scaffold の exit-2 記述を**まとめて削除**（終了コードは成功 0 / 失敗 1 に一本化）。`dry_eye` の doc が約束していた未実装関数 `dry_eye_with_seed` への参照を削除し、固定 seed=42 が `dry_eye.frag` との CPU↔GLSL 等価の前提である旨に是正（動画用 seed 対応は CPU/.frag 双方の uniform 化が要るためスコープ外）。
+
 ### Fixed
 
 - **fix: kako-jun/sensus#112 `split_mpo` の JPEG マーカー無視（素朴窓スキャン）を marker 走査に統一**: `split_mpo` は `windows(4)` で `FFD9 FFD8` を素朴スキャンしており、第1フレームの entropy-coded scan data や APPn ペイロード中に同バイト列があると誤分割しえた（session515 が `split_jpeg_frames` で直したのと同じ untrusted-input パーサのバグ class）。SOI から marker/length を正しく走査して**真の EOI** を見つける `first_jpeg_end()` を追加（SOS 後の entropy data の FF00 スタッフィング・FFDn RST を正しく読み飛ばす）。回帰テスト 3 件（APP1 ペイロードに埋め込んだ FFD9 FFD8 を誤認しない / SOS entropy + stuffing + RST を走査 / 非 SOI・EOI 欠落の拒否）。

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,7 +1,8 @@
 //! sensus CLI — simulate sensory perception on images.
 //!
-//! Phase 1 (Issue #2) 以降で各フィルタを実装する。本 scaffold (#1) では
-//! 引数を受け取り、未実装フィルタの場合は stderr に通知して exit(2) する。
+//! 画像/音声を読み、選択したフィルタを適用して出力する。エラーは stderr に通知し
+//! 非ゼロ終了する（成功 0 / 失敗 1）。core の `Filter` は全バリアント実装済みで、
+//! 未実装フィルタ経路（旧 exit-2）は持たない。
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -401,10 +402,6 @@ enum RunError {
         source: image::ImageError,
     },
 
-    /// A filter was selected but not yet implemented in core.
-    #[error("{0}")]
-    NotImplemented(String),
-
     /// A pipeline step failed at runtime.
     #[error("{0}")]
     Pipeline(String),
@@ -472,10 +469,6 @@ fn main() -> ExitCode {
         Err(RunError::AudioError(msg)) => {
             eprintln!("{msg}");
             ExitCode::FAILURE
-        }
-        Err(RunError::NotImplemented(msg)) => {
-            eprintln!("{msg}");
-            ExitCode::from(2)
         }
         Err(err) => {
             eprintln!("{err}");
@@ -594,8 +587,6 @@ fn run(cli: Cli) -> Result<(), RunError> {
         source,
     })?;
 
-    let (width, height) = (img.width(), img.height());
-
     // depth フィルタが含まれる場合は単独処理（Pipeline を通さない）
     // TODO(#19): Pipeline 統合時にここを削除し Pipeline 経由で処理する
     if cli.filter.iter().any(|f| f.is_depth_filter()) {
@@ -683,15 +674,6 @@ fn run(cli: Cli) -> Result<(), RunError> {
                     source,
                 })?;
             Ok(())
-        }
-        Err(CoreError::NotImplemented(filter)) => {
-            let msg = format!(
-                "sensus: filter {:?} (strength {:.2}) is not implemented yet.\n\
-                 sensus: input {}x{} {:?} -> output {:?}\n\
-                 sensus: see https://github.com/kako-jun/sensus for roadmap.",
-                filter, cli.strength, width, height, input_path, cli.output
-            );
-            Err(RunError::NotImplemented(msg))
         }
         Err(CoreError::Image(err)) => Err(RunError::InputOpen {
             path: input_path.clone(),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -8,11 +8,6 @@ use thiserror::Error;
 /// Errors produced by `sensus-core` filters and pipeline operations.
 #[derive(Debug, Error)]
 pub enum Error {
-    /// The requested filter is declared but not yet implemented.
-    /// Phase 1〜3 で順次解消される。
-    #[error("filter {0:?} is not implemented yet")]
-    NotImplemented(crate::Filter),
-
     /// Underlying [`image`] crate error (decode / encode / format).
     #[error("image processing error: {0}")]
     Image(#[from] image::ImageError),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,10 +27,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// v0.4.0 以降、一部バリアントはパラメータを直接 enum に埋め込む形式（案 A）。
 /// パラメータなしバリアントは `apply()` でデフォルト値を使用して適用される。
 ///
-/// Implemented filters return their result via [`apply`]; variants whose
-/// implementation has not yet landed return [`Error::NotImplemented`].
-/// The enum lives in `sensus-core` so non-CLI consumers (GUI, library
-/// users) can refer to filters without pulling in clap.
+/// すべてのバリアントは [`apply`] で実装済み（match は網羅的なので、新バリアントを
+/// 追加すると未実装はコンパイルエラーになる）。enum は `sensus-core` にあるため、
+/// 非 CLI consumer（GUI / ライブラリ利用者）は clap を持ち込まずにフィルタを参照できる。
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Filter {
     // vision (Phase 1: color vision deficiency)

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -2489,7 +2489,9 @@ pub fn metamorphopsia(img: DynamicImage, strength: f32, freq: f32, seed: u64) ->
 /// `strength = 0.0` は元画像と完全一致。
 ///
 /// シード値は内部で固定（42）のため、同一入力に対して毎回同一のノイズパターンになります。
-/// フレームごとに異なるパターンが必要な場合は将来の `dry_eye_with_seed(img, strength, seed)` を使用してください（未実装）。
+/// この固定 seed は `dry_eye.frag` の `tileHash` と一致させる CPU↔GLSL 等価の前提でもある。
+/// フレームごとに異なるパターン（動画用）を出すには CPU と `.frag` の双方に seed uniform を
+/// 通す必要があり、現状はスコープ外（必要になれば別途 seed 対応版を設計する）。
 ///
 /// #99: タイルノイズを行優先の逐次 64bit LCG から、タイル座標だけの決定論的 32bit
 /// spatial hash に変更した。これにより `dry_eye.frag` がフラグメント単位で同じノイズ場・


### PR DESCRIPTION
## 概要
監査 #111 の 2 点を解消。

## NotImplemented / exit-2 死にコード削除
全 `Filter` バリアントは実装済みで `apply()` の match は網羅的（新バリアントを未実装で追加すればコンパイルエラー）。したがって `Error::NotImplemented` は core から**二度と返らず**、CLI の exit-2 ハンドラは到達不能な死にコードだった。さらに `--pipe` 経路ではこの経路が `RunError::Pipeline`（exit 1）に誤マップされ、文書化された exit-2 契約と矛盾していた。

- core `Error::NotImplemented` を削除
- CLI `RunError::NotImplemented` + main() の exit-2 ハンドラ + run() の `CoreError::NotImplemented` arm を削除
- 旧 scaffold doc の exit-2 記述を是正（終了コードは成功 0 / 失敗 1 に一本化）
- 未使用になった `width`/`height` 束縛を削除

## dry_eye seed doc 是正
`dry_eye` の doc が「将来の `dry_eye_with_seed`（未実装）を使用してください」と**存在しない関数**を約束していた。固定 seed=42 が `dry_eye.frag` の `tileHash` との CPU↔GLSL 等価の前提である旨に是正（動画用の seed 対応は CPU/.frag 双方の uniform 化が要るためスコープ外と明記）。

## 検証
全 workspace test green（core 295）、clippy 0。CLI 統合テスト（pipe 含む）green。

closes #111