### PR TITLE
fix: #108 depth フィルタを他フィルタと合成可能に（CLI 合成）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **fix: kako-jun/sensus#108 depth フィルタを他フィルタと合成可能に（CLI 合成、hard error 解消）**: depth フィルタ（myopia-depth / hyperopia-depth / depth-of-field）は深度マップという第2入力が必要で Pipeline/Filter（単一画像）に載らないため、これまで他フィルタとの併用を hard error で拒否していた（`TODO(#19)`）。Pipeline を 2 入力対応に拡張する代わりに、**CLI 側で合成**する方針（#107 の「depth は単一入力契約に載せない」判断と整合）: 非 depth フィルタを Pipeline で先に適用し、その結果に `depth_aware_blur` をかける。`--depth` / `--mpo` / `--portrait` の 3 経路すべてで `--filter <color> --filter <depth>` の併用が可能に。depth フィルタは 1 つだけ許可（`depth_aware_blur` は単一 kind）。統合テスト 2 件（color+depth 合成が depth-only と異なる / depth 2 つは拒否）。
+
 ### Removed
 
 - **fix: kako-jun/sensus#111 死にコードの `Error::NotImplemented` / exit-2 経路を削除し、dry_eye の seed doc を是正**: 全 `Filter` バリアントは実装済みで `apply()` の match は網羅的（新バリアント追加は未実装ならコンパイルエラー）なため、`Error::NotImplemented` は core から二度と返らず、CLI の exit-2 ハンドラは到達不能な死にコードだった。さらに `--pipe` 経路ではこの経路が `RunError::Pipeline`（exit 1）に誤マップされ、文書化された exit-2 契約と矛盾していた。`Error::NotImplemented` / `RunError::NotImplemented` / 両ハンドラ / 旧 scaffold の exit-2 記述を**まとめて削除**（終了コードは成功 0 / 失敗 1 に一本化）。`dry_eye` の doc が約束していた未実装関数 `dry_eye_with_seed` への参照を削除し、固定 seed=42 が `dry_eye.frag` との CPU↔GLSL 等価の前提である旨に是正（動画用 seed 対応は CPU/.frag 双方の uniform 化が要るためスコープ外）。

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -489,19 +489,17 @@ fn run(cli: Cli) -> Result<(), RunError> {
     }
 
     // --mpo が指定されている場合のバリデーションと処理
-    if let Some(mpo_path) = cli.mpo {
-        // 複数フィルタとの組み合わせは不可
-        if cli.filter.len() > 1 {
-            return Err(RunError::MpoError(
-                "sensus: --mpo cannot be combined with multiple filters".to_string(),
-            ));
+    if let Some(mpo_path) = cli.mpo.clone() {
+        // depth フィルタは 1 つだけ必須（#108: 非 depth フィルタは合成可能）
+        let kinds = depth_kinds(&cli);
+        if kinds.len() != 1 {
+            return Err(RunError::MpoError(if kinds.is_empty() {
+                "sensus: --mpo requires a depth blur filter (myopia-depth, hyperopia-depth, depth-of-field)".to_string()
+            } else {
+                "sensus: --mpo accepts at most one depth blur filter".to_string()
+            }));
         }
-        // depth フィルタ以外は不可
-        if !cli.filter.iter().any(|f| f.is_depth_filter()) {
-            return Err(RunError::MpoError(
-                "sensus: --mpo requires a depth blur filter (myopia-depth, hyperopia-depth, depth-of-field)".to_string(),
-            ));
-        }
+        let kind = kinds[0];
         // --depth との同時指定は不可
         if cli.depth.is_some() {
             return Err(RunError::MpoError(
@@ -509,7 +507,6 @@ fn run(cli: Cli) -> Result<(), RunError> {
             ));
         }
 
-        let kind = cli.filter[0].depth_kind().unwrap();
         let bytes = std::fs::read(&mpo_path).map_err(|source| RunError::MpoRead {
             path: mpo_path.clone(),
             source,
@@ -518,7 +515,9 @@ fn run(cli: Cli) -> Result<(), RunError> {
             .map_err(|e| RunError::MpoError(format!("sensus: {e}")))?;
         let depth_img = stereo_to_depth(&left, &right)
             .map_err(|e| RunError::MpoError(format!("sensus: {e}")))?;
-        let out = depth_aware_blur(left, &depth_img, cli.focus, cli.strength * DEPTH_BLUR_MAX_RADIUS_RATIO, kind)
+        // #108: depth 以外のフィルタを左目画像に先に適用してから depth blur
+        let base = apply_non_depth_filters(left, &cli)?;
+        let out = depth_aware_blur(base, &depth_img, cli.focus, cli.strength * DEPTH_BLUR_MAX_RADIUS_RATIO, kind)
             .map_err(|e| RunError::Pipeline(format!("sensus: {e}")))?;
         let out_path = cli.output.as_ref().unwrap();
         return out.save(out_path).map_err(|source| RunError::OutputSave {
@@ -528,17 +527,17 @@ fn run(cli: Cli) -> Result<(), RunError> {
     }
 
     // --portrait: Android XMP Depth
-    if let Some(portrait_path) = cli.portrait {
-        if cli.filter.len() > 1 {
-            return Err(RunError::PortraitError(
-                "sensus: --portrait cannot be combined with multiple filters".to_string(),
-            ));
+    if let Some(portrait_path) = cli.portrait.clone() {
+        // depth フィルタは 1 つだけ必須（#108: 非 depth フィルタは合成可能）
+        let kinds = depth_kinds(&cli);
+        if kinds.len() != 1 {
+            return Err(RunError::PortraitError(if kinds.is_empty() {
+                "sensus: --portrait requires a depth blur filter (myopia-depth, hyperopia-depth, depth-of-field)".to_string()
+            } else {
+                "sensus: --portrait accepts at most one depth blur filter".to_string()
+            }));
         }
-        if !cli.filter.iter().any(|f| f.is_depth_filter()) {
-            return Err(RunError::PortraitError(
-                "sensus: --portrait requires a depth blur filter (myopia-depth, hyperopia-depth, depth-of-field)".to_string(),
-            ));
-        }
+        let kind = kinds[0];
         if cli.depth.is_some() {
             return Err(RunError::PortraitError(
                 "sensus: --portrait and --depth cannot be used together".to_string(),
@@ -565,8 +564,9 @@ fn run(cli: Cli) -> Result<(), RunError> {
             })?
         };
 
-        let kind = cli.filter[0].depth_kind().unwrap();
-        let out = depth_aware_blur(source_img, &depth_map, cli.focus, cli.strength * DEPTH_BLUR_MAX_RADIUS_RATIO, kind)
+        // #108: depth 以外のフィルタを先に適用してから depth blur
+        let base = apply_non_depth_filters(source_img, &cli)?;
+        let out = depth_aware_blur(base, &depth_map, cli.focus, cli.strength * DEPTH_BLUR_MAX_RADIUS_RATIO, kind)
             .map_err(|e| RunError::PortraitError(format!("sensus: {e}")))?;
         let out_path = cli.output.as_ref().unwrap();
         return out.save(out_path).map_err(|source| RunError::OutputSave {
@@ -576,7 +576,7 @@ fn run(cli: Cli) -> Result<(), RunError> {
     }
 
     // --mpo なし・--portrait なし → --input が必須
-    let input_path = cli.input.ok_or_else(|| {
+    let input_path = cli.input.clone().ok_or_else(|| {
         RunError::InputRequired(
             "sensus: --input is required when --mpo and --portrait are not specified".to_string(),
         )
@@ -587,15 +587,15 @@ fn run(cli: Cli) -> Result<(), RunError> {
         source,
     })?;
 
-    // depth フィルタが含まれる場合は単独処理（Pipeline を通さない）
-    // TODO(#19): Pipeline 統合時にここを削除し Pipeline 経由で処理する
+    // depth フィルタが含まれる場合（#108: 非 depth フィルタを先に合成してから depth blur）
     if cli.filter.iter().any(|f| f.is_depth_filter()) {
-        if cli.filter.len() > 1 {
+        let kinds = depth_kinds(&cli);
+        if kinds.len() != 1 {
             return Err(RunError::Pipeline(
-                "sensus: depth blur filters cannot be combined with other filters".to_string(),
+                "sensus: exactly one depth blur filter is allowed (myopia-depth / hyperopia-depth / depth-of-field)".to_string(),
             ));
         }
-        let kind = cli.filter[0].depth_kind().unwrap();
+        let kind = kinds[0];
 
         let depth_path = cli.depth.as_ref().ok_or_else(|| {
             RunError::Pipeline(
@@ -606,7 +606,9 @@ fn run(cli: Cli) -> Result<(), RunError> {
             path: depth_path.clone(),
             source,
         })?;
-        let out = depth_aware_blur(img, &depth_img, cli.focus, cli.strength * DEPTH_BLUR_MAX_RADIUS_RATIO, kind)
+        // #108: depth 以外のフィルタを先に適用してから depth blur で合成
+        let base = apply_non_depth_filters(img, &cli)?;
+        let out = depth_aware_blur(base, &depth_img, cli.focus, cli.strength * DEPTH_BLUR_MAX_RADIUS_RATIO, kind)
             .map_err(|e| RunError::Pipeline(format!("sensus: {e}")))?;
         let out_path = cli.output.as_ref().unwrap();
         return out.save(out_path).map_err(|source| RunError::OutputSave {
@@ -725,6 +727,46 @@ fn apply_filters_to_image(
 ) -> Result<image::DynamicImage, RunError> {
     let mut pipeline = Pipeline::new();
     for f in &cli.filter {
+        let core_filter = f.to_core();
+        let mut step = FilterStep::new(core_filter, cli.strength);
+        step.axis = cli.axis;
+        step.seed = cli.seed;
+        step.density = cli.density;
+        step.gaze_x = cli.gaze_x;
+        step.gaze_y = cli.gaze_y;
+        step.side = cli.side;
+        step.offset_x = cli.offset_x;
+        step.offset_y = cli.offset_y;
+        step.ghost_strength = cli.ghost_strength;
+        step.amplitude = cli.amplitude;
+        step.direction_deg = cli.direction_deg;
+        step.num_rays = cli.num_rays;
+        step.ray_length_ratio = cli.ray_length;
+        step.threshold = cli.threshold;
+        pipeline = pipeline.push(step);
+    }
+    pipeline
+        .apply(img)
+        .map_err(|e| RunError::Pipeline(format!("sensus: {e}")))
+}
+
+/// cli.filter 中の depth フィルタの kind 一覧（#108）。
+fn depth_kinds(cli: &Cli) -> Vec<DepthBlurKind> {
+    cli.filter.iter().filter_map(|f| f.depth_kind()).collect()
+}
+
+/// depth **以外**のフィルタを Pipeline で `img` に適用する（#108 の合成用）。
+///
+/// depth フィルタは深度マップという第2入力が必要で Pipeline に載らないため、CLI 側で
+/// 「非 depth フィルタを先に適用 → その結果に depth_aware_blur」と合成する。非 depth
+/// フィルタが無ければ `img` をそのまま返す。
+fn apply_non_depth_filters(
+    img: image::DynamicImage,
+    cli: &Cli,
+) -> Result<image::DynamicImage, RunError> {
+    // 非 depth フィルタだけで Pipeline を組む。空なら Pipeline::apply は恒等。
+    let mut pipeline = Pipeline::new();
+    for f in cli.filter.iter().filter(|f| !f.is_depth_filter()) {
         let core_filter = f.to_core();
         let mut step = FilterStep::new(core_filter, cli.strength);
         step.axis = cli.axis;

--- a/crates/cli/tests/depth_compose_integration.rs
+++ b/crates/cli/tests/depth_compose_integration.rs
@@ -1,0 +1,85 @@
+//! Integration tests for #108: composing non-depth filters with a depth blur
+//! filter at the CLI (`--filter <color> --filter <depth> --depth <map>`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn sensus_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sensus"))
+}
+
+/// 色のある入力画像（protanopia で変化が出る）を書く。
+fn write_input(path: &Path) {
+    use image::{DynamicImage, RgbImage};
+    let img = RgbImage::from_fn(32, 32, |x, _y| image::Rgb([(x * 8) as u8, 200, 60]));
+    DynamicImage::ImageRgb8(img).save(path).unwrap();
+}
+
+/// 水平グラデーションの深度マップ（depth blur が効く）。
+fn write_depth(path: &Path) {
+    use image::{DynamicImage, GrayImage};
+    let img = GrayImage::from_fn(32, 32, |x, _y| image::Luma([(x * 8) as u8]));
+    DynamicImage::ImageLuma8(img).save(path).unwrap();
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(sensus_bin()).args(args).output().unwrap()
+}
+
+#[test]
+fn depth_filter_composes_with_color_filter() {
+    let dir = tempfile::tempdir().unwrap();
+    let inp = dir.path().join("in.png");
+    let depth = dir.path().join("d.png");
+    let out_compose = dir.path().join("compose.png");
+    let out_depth_only = dir.path().join("depth_only.png");
+    write_input(&inp);
+    write_depth(&depth);
+
+    // 合成: protanopia → myopia-depth（#108 で hard error が解消され成功する）
+    let s1 = run(&[
+        "-i", inp.to_str().unwrap(),
+        "--depth", depth.to_str().unwrap(),
+        "-o", out_compose.to_str().unwrap(),
+        "--filter", "protanopia", "--filter", "myopia-depth",
+        "-s", "1.0",
+    ]);
+    assert!(s1.status.success(), "compose should succeed: {}", String::from_utf8_lossy(&s1.stderr));
+    assert!(out_compose.exists());
+
+    // depth のみ
+    let s2 = run(&[
+        "-i", inp.to_str().unwrap(),
+        "--depth", depth.to_str().unwrap(),
+        "-o", out_depth_only.to_str().unwrap(),
+        "--filter", "myopia-depth",
+        "-s", "1.0",
+    ]);
+    assert!(s2.status.success());
+
+    // protanopia が前段で効くので、合成結果は depth-only と異なるはず
+    let a = image::open(&out_compose).unwrap().to_rgba8();
+    let b = image::open(&out_depth_only).unwrap().to_rgba8();
+    assert_ne!(a.as_raw(), b.as_raw(), "composed output must differ from depth-only (color filter applied first)");
+}
+
+#[test]
+fn two_depth_filters_are_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let inp = dir.path().join("in.png");
+    let depth = dir.path().join("d.png");
+    let out = dir.path().join("out.png");
+    write_input(&inp);
+    write_depth(&depth);
+
+    // depth フィルタ 2 つは不可（depth_aware_blur は単一 kind）
+    let o = run(&[
+        "-i", inp.to_str().unwrap(),
+        "--depth", depth.to_str().unwrap(),
+        "-o", out.to_str().unwrap(),
+        "--filter", "myopia-depth", "--filter", "hyperopia-depth",
+    ]);
+    assert!(!o.status.success(), "two depth filters must be rejected");
+    let stderr = String::from_utf8_lossy(&o.stderr);
+    assert!(stderr.contains("depth blur filter"), "error should mention depth blur filter: {stderr}");
+}


### PR DESCRIPTION
## 概要
depth フィルタ（myopia-depth / hyperopia-depth / depth-of-field）は**深度マップという第2入力**が必要で Pipeline / Filter（単一画像）に載らないため、これまで他フィルタとの併用を hard error で拒否していた（`TODO(#19)`、監査 #108）。

## 方針（CLI 合成）
Pipeline を 2 入力対応に拡張する大改修は避け、**CLI 側で合成**する（#107 の「depth は単一入力契約に載せない」判断と整合）:
- 非 depth フィルタを Pipeline で先に適用 → その結果に `depth_aware_blur` をかける
- `--depth` / `--mpo` / `--portrait` の 3 経路すべてで `--filter <color> --filter <depth>` 併用が可能に
- depth フィルタは **1 つだけ許可**（`depth_aware_blur` は単一 kind）。0 個 / 2 個以上はエラー
- `apply_non_depth_filters` / `depth_kinds` ヘルパー追加。`cli.mpo/portrait/input` を clone して部分ムーブを回避

## テスト
- `depth_filter_composes_with_color_filter`: protanopia → myopia-depth 合成が成功し、depth-only と出力が異なる（前段の色フィルタが効いている）
- `two_depth_filters_are_rejected`: depth 2 つは拒否
- 既存 mpo/portrait/pipe/cli 統合テスト green、workspace 471 tests、clippy 0

closes #108