### PR TITLE
chore: #113 v0.1-0.2 コア独立レビュー — 色覚関数の strength 正規化を共通化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **chore: kako-jun/sensus#113 v0.1-0.2 コア独立レビュー実施 — 色覚関数の strength 正規化を共通化**: 5 ラウンドレビュー（#68-#90）が未カバーだった v0.1-0.2 コア（色覚行列・視野マスク・初代 hearing DSP・stereo/MPO/XMP パーサ・SAD 深度推定）を correctness 観点で精査。**致命的なバグは検出されず**（パーサは bounds-checked、SAD は overflow なし、色覚・マスクは linear 空間で clamp 済み）。唯一の整合性所見として、色覚関数（`apply_machado_matrix` / `achromatopsia`）が `normalize_strength` 相当の NaN/clamp 処理をインラインで重複していたのを、#120 で `pub(crate)` 化した `normalize_strength` に統一。挙動は不変（`achromatopsia_nan_strength_returns_identity` 等で確認）。
+
 - **fix: kako-jun/sensus#108 depth フィルタを他フィルタと合成可能に（CLI 合成、hard error 解消）**: depth フィルタ（myopia-depth / hyperopia-depth / depth-of-field）は深度マップという第2入力が必要で Pipeline/Filter（単一画像）に載らないため、これまで他フィルタとの併用を hard error で拒否していた（`TODO(#19)`）。Pipeline を 2 入力対応に拡張する代わりに、**CLI 側で合成**する方針（#107 の「depth は単一入力契約に載せない」判断と整合）: 非 depth フィルタを Pipeline で先に適用し、その結果に `depth_aware_blur` をかける。`--depth` / `--mpo` / `--portrait` の 3 経路すべてで `--filter <color> --filter <depth>` の併用が可能に。depth フィルタは 1 つだけ許可（`depth_aware_blur` は単一 kind）。統合テスト 2 件（color+depth 合成が depth-only と異なる / depth 2 つは拒否）。
 
 ### Removed

--- a/crates/core/src/vision.rs
+++ b/crates/core/src/vision.rs
@@ -167,14 +167,8 @@ pub fn tritanopia(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
 /// `strength = 1.0` で完全グレースケール (R == G == B)。`strength = 0.0` で原画像。
 /// 中間値は linear sRGB 空間で線形補間。
 pub fn achromatopsia(img: DynamicImage, strength: f32) -> Result<DynamicImage> {
-    // NaN strength は identity（元画像）として扱う。
-    // f32::NAN.clamp(0.0, 1.0) は NaN のままだが、上流で 0.0 に置換しているので
-    // silent な全画素 0 出力にはならない。
-    let strength = if strength.is_nan() {
-        0.0
-    } else {
-        strength.clamp(0.0, 1.0)
-    };
+    // strength を正規化（NaN→0 / clamp 0..1）。CPU 全段共通の正規化を使う（#113）。
+    let strength = normalize_strength(strength);
     let mut rgba = img.to_rgba8();
 
     // strength == 0.0 のショートカット（元画像と完全一致を保証）。
@@ -213,14 +207,8 @@ fn apply_machado_matrix(
     matrix: &[[f32; 3]; 3],
     strength: f32,
 ) -> Result<DynamicImage> {
-    // NaN strength は identity（元画像）として扱う。
-    // f32::NAN.clamp(0.0, 1.0) は NaN のままだが、上流で 0.0 に置換しているので
-    // silent な全画素 0 出力にはならない。
-    let strength = if strength.is_nan() {
-        0.0
-    } else {
-        strength.clamp(0.0, 1.0)
-    };
+    // strength を正規化（NaN→0 / clamp 0..1）。CPU 全段共通の正規化を使う（#113）。
+    let strength = normalize_strength(strength);
     let mut rgba: RgbaImage = img.to_rgba8();
 
     if strength == 0.0 {


### PR DESCRIPTION
## 概要
監査 #113。5 ラウンドレビュー（#68-#90）が未カバーだった v0.1-0.2 コアを correctness 観点で独立レビューした。

## レビュー範囲と結論
精査対象: 色覚行列（protanopia/deuteranopia/tritanopia/achromatopsia）・視野マスク（hemianopia 等）・初代 hearing DSP（biquad/hearing_loss）・stereo/MPO/XMP パーサ（read_xmp_depth / base64_decode / extract_gdepth_data / split_mpo）・SAD 深度推定（stereo_to_depth）。

**致命的な correctness バグは検出されず**:
- パーサ群は bounds-checked（`seg_len < 2` / `seg_end > len` で break、base64 は不正文字を reject）。`split_mpo` の素朴スキャンは #112 で marker 走査に修正済み。
- `stereo_to_depth` の SAD は index クランプ済み・u32 overflow なし。
- 色覚・マスクは linear sRGB 空間で blend → `pack_u8` で clamp。NaN 処理あり。

## 唯一の整合性所見（修正）
`apply_machado_matrix` / `achromatopsia` が `normalize_strength` 相当の NaN/clamp 処理をインラインで重複していた。#120 で `pub(crate)` 化した `normalize_strength` に統一。**挙動は不変**（`achromatopsia_nan_strength_returns_identity` 等 green）。

core 295 / clippy 0。

closes #113