### PR TITLE
再監査フォローアップ: 医学注記2件 / nystagmus 大半径 cap 明記 / param pipeline 等価テスト

### DIFF
--- a/crates/core/src/pipeline.rs
+++ b/crates/core/src/pipeline.rs
@@ -226,6 +226,54 @@ mod tests {
         assert_eq!(via_pipeline, direct);
     }
 
+    /// パラメータ付きバリアントでも Pipeline::apply() == crate::apply()。
+    /// （パラメータが payload から正しく伝わることの byte-exact 保証。）
+    #[test]
+    fn parameterized_step_matches_direct_apply() {
+        let make = || {
+            let mut img = RgbImage::new(48, 48);
+            for (x, y, px) in img.enumerate_pixels_mut() {
+                *px = image::Rgb([(x * 5) as u8, (y * 5) as u8, 90]);
+            }
+            DynamicImage::ImageRgb8(img)
+        };
+        for filter in [
+            Filter::Astigmatism { axis_deg: 45.0 },
+            Filter::Diplopia {
+                offset_x: 0.05,
+                offset_y: 0.03,
+                ghost_strength: 0.6,
+            },
+            Filter::Nystagmus {
+                amplitude: 0.08,
+                direction_deg: 30.0,
+            },
+            Filter::Floaters {
+                seed: 3,
+                density: 0.7,
+                size: 1.5,
+                gaze_x: 0.3,
+                gaze_y: 0.8,
+            },
+            Filter::Metamorphopsia { freq: 6.0, seed: 9 },
+        ] {
+            let via_pipeline = Pipeline::new()
+                .push(FilterStep::new(filter, 0.9))
+                .apply(make())
+                .unwrap()
+                .to_rgba8()
+                .into_raw();
+            let direct = crate::apply(filter, make(), 0.9)
+                .unwrap()
+                .to_rgba8()
+                .into_raw();
+            assert_eq!(
+                via_pipeline, direct,
+                "pipeline must match direct apply for {filter:?}"
+            );
+        }
+    }
+
     /// A→B と B→A で結果が異なることを確認する（順序依存性のテスト）。
     #[test]
     fn two_step_order_matters() {

--- a/crates/core/src/shaders/nystagmus.frag
+++ b/crates/core/src/shaders/nystagmus.frag
@@ -18,6 +18,12 @@ uniform vec2  uTexelSize;      // vec2(1.0/width, 1.0/height)
 in vec2 vTexCoord;
 out vec4 fragColor;
 
+// RMAX=15 はカーネル半径（タップ）の上限。CPU `ellipse_blur` は半径無制限なので、
+// `uRadiusPx > 15` では GLSL が CPU より弱くぼけ、両者は乖離する。
+// nystagmus の半径は `amplitude × strength × min(W,H)` で、既定 amplitude=0.03 では
+// min(W,H) ≳ 500 px で 15 px を超える（astigmatism は 0.011×min なので ≳1363 px）。
+// 大半径で CPU↔GLSL の厳密一致が要るなら、per-pixel ボックスではなく
+// 軸方向の固定タップ数サンプリングへ書き換えること（別 issue）。
 const int RMAX = 15;
 const float B_RADIUS = 0.5;
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -589,6 +589,13 @@ same math. A GPU-free software equivalence test suite (`#17`) asserts that
 CPU and shader outputs agree within ≤ 2/255 per channel (matrix filters) or
 PSNR ≥ 30 dB (blur / directional filters).
 
+> **Known limitation** — the 1D directional-blur shaders (`nystagmus`,
+> `astigmatism`) cap their per-pixel kernel at `RMAX = 15` taps, while the CPU
+> blur radius is unbounded. They diverge once the blur radius exceeds ~15 px
+> (`nystagmus`: default amplitude on images wider than ~500 px; `astigmatism`:
+> only above ~1363 px). The CPU / CLI path is unaffected. A fixed-tap rewrite
+> of these two shaders is tracked as a follow-up.
+
 ## Medical notes (when to see a doctor)
 
 sensus pairs each filter with a "when to see a doctor" note so the simulation
@@ -611,7 +618,8 @@ doubles as an early-warning primer. The urgency vocabulary matches the
 | `contrast_sensitivity`, `detail_loss`, `eye_strain` | None | Often lighting/fatigue related; persistent change → eye exam. |
 | `dry_eye` | None / ⚠️ | Usually benign; persistent pain or vision change → consult. |
 | `starbursts` | ⚠️ early consultation | New night-time halos can accompany cataract or refractive error. |
-| `glaucoma` | ⚠️ early consultation | Painless peripheral loss; early detection preserves the field. |
+| `glaucoma`, `tunnel_vision` | ⚠️ early consultation | Painless peripheral / tunnel field loss; early detection (glaucoma, retinitis pigmentosa) preserves the field. |
+| `photophobia` | None / ⚠️ | Often benign light sensitivity; sudden severe photophobia with eye pain / headache → evaluate (iritis, migraine). |
 | `macular_degeneration`, `metamorphopsia` | ⚠️ early consultation | Central distortion/blur; early treatment slows progression. |
 | `cataract` | ⚠️ early consultation | Progressive clouding; rapid change warrants an exam. |
 | `night-blindness` (`nyctalopia`) | ⚠️ early consultation | Rapid worsening may mean vitamin-A deficiency / RP. |


### PR DESCRIPTION
PR #154（完成監査パス）後の独立再監査で確定した残課題に対応。

## 再監査の結論
独立3視点（リファクタ正当性 / コア math 深掘り / docs 再整合）で再点検。**リファクタは正当（パラメータ配線・既定値保存・vertigo/bppv ピーク位相を数値検証で確認、dead code なし）**。確定した実害は以下のみ:

1. **(Medium, 既存 GLSL 制約)** `nystagmus` シェーダが `RMAX=15` でカーネルを打ち切るが CPU は無制限 → 既定 amplitude で min(W,H)≳500px の画像から CPU↔GLSL が乖離（等価テストは amplitude 0.1・小画像で見逃し）。`astigmatism` も同 cap だが半径 0.011×min なので ≳1363px でのみ。**CPU/CLI 経路は影響なし**（GLSL は未接続の universal-experience 用）。astigmatism は 0.4.0 で既に同 cap を明記済みの前例あり。
2. **(Low-Medium)** overview.md の医学注記表に `tunnel_vision` / `photophobia` の行が欠落。

## 対応
- 医学注記表に2フィルタ追加（全 vision フィルタを網羅）。
- nystagmus.frag と overview に大半径 cap を**既知制約として明記**（契約を正直に）。固定タップへの書き換えは等価テスト基盤の再調整を要するため別 issue のフォローアップ。
- `parameterized_step_matches_direct_apply` テスト追加（payload 配線の byte-exact 保証）。

## 検証
fmt --check ✅ / clippy -D warnings ✅ / 全テスト緑（core **298** + shader **148** + 統合）。