### PR TITLE
docs: 設計判断 ADR + 行列出自 spec を整備（docs/adr/ 新設）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ sensus/
 
 ## 主要な設計判断
 
+> formal な ADR（問題 / 選択肢 / 選定理由 / トレードオフ）は `docs/adr/` を正本とする。以下は散在サマリ。行列の出自は `docs/adr/matrix-provenance.md`。
+
 - **WASM ターゲットは持たない** — sensus の主クライアントは universal-experience（Flutter の native）。Web GUI はやらない方針なので、wasm32 用の getrandom 等の追加依存は避ける
 - **入出力は `image::DynamicImage` で統一** — orber と同じ規約。動画はフレーム単位で同関数を呼ぶ
 - **CLI の終了コードは成功 0 / 失敗 1 の 2 値**（#111 で旧 scaffold の未実装 `exit(2)` 経路を削除済み。全 `Filter` バリアントは実装済みで `apply()` の match は網羅的）

--- a/docs/adr/0001-linear-srgb-machado-matrices.md
+++ b/docs/adr/0001-linear-srgb-machado-matrices.md
@@ -1,0 +1,76 @@
+# 0001 — Operate color-vision simulation in linear sRGB, applying Machado 2009 matrices directly (no explicit LMS pipeline)
+
+## Status
+
+Accepted.
+
+## Context
+
+Color vision deficiency (CVD) simulation conceptually lives in cone (LMS)
+space: the deficiency is a loss or shift of one cone type. A textbook pipeline
+would therefore be `sRGB → linear sRGB → LMS → (deficiency transform) → linear
+sRGB → sRGB`, carrying explicit LMS conversion matrices and a cone-response
+model.
+
+`sensus` needs CVD simulation for protanopia, deuteranopia, and tritanopia. It
+must produce color-scientifically defensible output and be cheap enough to run
+per-frame for video.
+
+## Decision
+
+Operate the simulation **entirely in linear sRGB** and apply the
+**Machado, Oliveira & Fernandes (2009)** pre-computed `severity = 1.0` matrices
+**directly** as `linear sRGB → simulated linear sRGB`. Do **not** build an
+explicit LMS pipeline.
+
+Pixels are gamma-decoded (`srgb_to_linear`), the 3×3 matrix is multiplied in
+linear space, and the result is gamma-encoded back to sRGB
+(`linear_to_srgb`). Alpha is preserved.
+
+## Alternatives considered
+
+1. **Explicit LMS pipeline** — convert to LMS, apply a cone-loss transform,
+   convert back. This is the "from first principles" route.
+2. **Multiply the matrix against gamma-encoded sRGB** (skip the linearization).
+   This is the common naïve shortcut seen in many web demos.
+3. **Use Machado's pre-computed linear-sRGB matrices directly** (chosen).
+
+## Rationale
+
+- Machado et al. already pre-multiplied the cone-space physiology into a single
+  linear-sRGB→linear-sRGB matrix per deficiency and severity. Re-deriving an
+  LMS pipeline would reproduce the same published result with more code, more
+  constants to get wrong, and no fidelity gain — the physiology is *already
+  baked into* the published matrix.
+- The matrices are a published, peer-reviewed, citable artefact (IEEE TVCG,
+  DOI: 10.1109/TVCG.2009.113), with the author's supplementary page and the
+  DaltonLens project carrying identical values. Using them directly keeps the
+  output auditable against an external reference (see
+  [`matrix-provenance.md`](matrix-provenance.md)).
+- Doing the math in **linear** sRGB is mandatory for correctness: multiplying a
+  color matrix against gamma-encoded sRGB darkens midtones and is
+  color-scientifically wrong (alternative 2 is rejected on these grounds, per
+  `docs/overview.md` "Color vision algorithm").
+
+## Consequences / Trade-offs
+
+- **Gain:** minimal, auditable code; output that can be cross-checked against
+  the published source values; a single matrix multiply per pixel (cheap enough
+  for per-frame video).
+- **Gain:** no separate LMS conversion matrices to maintain or get wrong.
+- **Cost:** the simulation is only as good as the Machado matrices; we cannot
+  independently tune cone responses without replacing the source matrices (a
+  change that would have to update both the const and the provenance spec — see
+  ADR-0002 and `matrix-provenance.md`).
+- **Cost:** gamma decode/encode runs per pixel; this is the price of doing the
+  math in linear space (and is shared by every other linear-sRGB filter).
+
+## References
+
+- `docs/overview.md` — "Color vision algorithm (Phase 1, #2)".
+- `crates/core/src/vision.rs` — module docstring (`## protanopia / deuteranopia
+  / tritanopia`, `# 色空間`) and `PROTANOPIA` / `DEUTERANOPIA` / `TRITANOPIA`
+  const definitions; `apply_machado_matrix`.
+- `CLAUDE.md` — "主要な設計判断": *色覚特性は linear sRGB + Machado 2009
+  severity=1.0 行列*.
+- [`matrix-provenance.md`](matrix-provenance.md).

--- a/docs/adr/0002-linear-blend-intermediate-severity.md
+++ b/docs/adr/0002-linear-blend-intermediate-severity.md
@@ -1,0 +1,77 @@
+# 0002 — Linear blend for intermediate severity
+
+## Status
+
+Accepted.
+
+## Context
+
+The published Machado 2009 matrices used by `sensus` (see ADR-0001) are the
+`severity = 1.0` matrices: full dichromacy. But the `strength` parameter is
+normalized to `0.0..=1.0`, where `0.0` must return the original image and
+intermediate values must represent partial / anomalous trichromacy (mild color
+vision deficiency).
+
+Machado et al. publish a *family* of matrices indexed by severity, so one
+option is to interpolate between published matrices. The question is how to map
+an arbitrary `strength` to a partial effect.
+
+## Decision
+
+Compute the full `severity = 1.0` simulated color, then blend it with the
+original in **linear sRGB space**:
+
+```
+n = original + (simulated - original) * strength
+```
+
+i.e. `lerp(original, simulated, strength)` per channel, in linear space, applied
+identically for protanopia / deuteranopia / tritanopia (and the achromatopsia
+grayscale target — see ADR-0004).
+
+## Alternatives considered
+
+1. **Interpolate between Machado's per-severity matrices** — carry the full
+   table of matrices (severity 0.0…1.0 in 0.1 steps) and pick / interpolate by
+   `strength`.
+2. **Blend in gamma-encoded sRGB** — lerp after gamma encoding.
+3. **Linear-space lerp between original and the severity-1.0 result** (chosen).
+
+## Rationale
+
+- A linear-space lerp toward the full-deficiency result is the linearised
+  approximation of anomalous trichromacy that Machado himself suggests and that
+  DaltonLens et al. adopt — it is an accepted, documented practice, not an
+  invention of this project.
+- It needs only the single `severity = 1.0` matrix per deficiency, keeping the
+  constant set small and the provenance story simple (one cited matrix per type,
+  per [`matrix-provenance.md`](matrix-provenance.md)) instead of an
+  eleven-entry table to source and pin.
+- Blending must happen in **linear** space for the same reason the matrix is
+  applied in linear space (ADR-0001): a gamma-space lerp is photometrically
+  wrong (alternative 2 rejected).
+
+## Consequences / Trade-offs
+
+- **Gain:** a single source matrix per deficiency; trivially exact identity at
+  `strength = 0.0`; a continuous, monotone slider for partial CVD.
+- **Gain:** the blend is one shared code path across all four color-vision
+  filters, so the KAT can verify it once and trust it everywhere
+  (`crates/core/tests/color_kat.rs`, `cross_check_*_mid_strength`).
+- **Cost:** intermediate `strength` is an *approximation* of anomalous
+  trichromacy, not the exact per-severity Machado matrix. The error is largest
+  at mid severities, where the true anomalous matrix is not a linear blend of
+  identity and the dichromat matrix. We accept this because it is the
+  conventional approximation and keeps the matrix set minimal.
+
+## References
+
+- `docs/overview.md` — "Color vision algorithm (Phase 1, #2)": *applies the
+  published severity = 1.0 matrix and uses `lerp(original, simulated, strength)`
+  in linear space*.
+- `crates/core/src/vision.rs` — module docstring (`中間 strength は Machado 自身
+  が示唆する通り … DaltonLens 等で広く採用されている方式`); blend step in
+  `apply_machado_matrix` and `achromatopsia`.
+- `CLAUDE.md` — "主要な設計判断": *中間 strength は linear 空間で補間する*.
+- `crates/core/tests/color_kat.rs` — `cross_check_protanopia_mid_strength`,
+  `cross_check_deuteranopia_mid_strength` (pins the blend at `strength = 0.5`).

--- a/docs/adr/0003-disk-blur-not-gaussian.md
+++ b/docs/adr/0003-disk-blur-not-gaussian.md
@@ -1,0 +1,70 @@
+# 0003 — Disk (pillbox) blur for defocus / refraction, not Gaussian
+
+## Status
+
+Accepted.
+
+## Context
+
+The refraction filters (`myopia`, `hyperopia`, `presbyopia`, and the cylinder
+component of `astigmatism`) simulate optical defocus. Defocus needs a blur
+kernel. The default reflex in image processing is a Gaussian blur, because it
+is separable, cheap, and a good de-noising prior.
+
+The question is which point-spread function (PSF) correctly models a defocused
+human eye.
+
+## Decision
+
+Use a **disk (pillbox) blur** — a uniform-density circular kernel — for
+isotropic defocus (`myopia` / `hyperopia` / `presbyopia`), computed in linear
+sRGB. Do **not** use a Gaussian. For `astigmatism`, use the degenerate
+1-dimensional case of the same construction (a directional box filter — the line
+spread function of a pure cylinder lens; see also `docs/overview.md`
+"Astigmatism").
+
+## Alternatives considered
+
+1. **Gaussian blur** — separable, fast, conventional.
+2. **Disk / pillbox blur** (chosen) — uniform circular kernel matching the
+   pupil shape.
+
+## Rationale
+
+- A point light source out of focus images on the retina as a **circle of
+  confusion**, not a Gaussian falloff. The eye's pupil acts as the aperture, so
+  the impulse response (PSF) of a defocused eye is the *shape of the pupil* — a
+  uniform-density disk to first approximation. Disk blur is therefore the
+  optically correct PSF; Gaussian is not what a defocused eye produces.
+- The disk radius is derived from physical optics (Smith–Helmholtz
+  approximation; pupil diameter × diopters → angular CoC diameter → radius). A
+  Gaussian has no single radius that corresponds to a given diopter of defocus,
+  so it could not carry the same physically-grounded `diopter → pixel-radius`
+  mapping (see `docs/overview.md` "Diopter → pixel-radius mapping").
+- The implementation keeps disk blur affordable: per-row spans of the disk plus
+  a horizontal prefix sum give `O(W·H·kernel_height)` instead of the naïve
+  `O(W·H·R²)`, so the optical-fidelity choice does not cost an impractical
+  runtime.
+
+## Consequences / Trade-offs
+
+- **Gain:** optically faithful defocus — the simulation matches the physics of
+  the eye, which is the project's stated priority (fidelity over visual
+  exaggeration).
+- **Gain:** a single physical model (pupil-as-aperture) drives both the kernel
+  shape *and* the radius, so the parameters stay internally consistent.
+- **Cost:** disk blur is not separable like a Gaussian, so it needs the prefix-sum
+  trick to stay fast; the naïve form is `O(R²)` per pixel.
+- **Cost:** a uniform disk has a hard edge and visible ringing on point
+  highlights compared with the soft Gaussian — but that ring *is* the real
+  circle-of-confusion appearance, so it is a feature, not a defect.
+
+## References
+
+- `docs/overview.md` — refraction section (`circle of confusion (CoC)` … *uses
+  disk blur for physical correctness*) and "Diopter → pixel-radius mapping".
+- `crates/core/src/vision.rs` — module docstring (`Gaussian は実際の defocus
+  blur ではないため採用しない …`); `MYOPIA_MAX_RADIUS_RATIO` and sibling
+  derivation comments; `MIN_BLUR_RADIUS_PX`.
+- `CLAUDE.md` — "主要な設計判断": *焦点・屈折 (Phase 2 / #4) は disk blur
+  (pillbox) を linear sRGB で適用 — Gaussian は採用しない*.

--- a/docs/adr/0004-achromatopsia-bt709-photopic.md
+++ b/docs/adr/0004-achromatopsia-bt709-photopic.md
@@ -1,0 +1,79 @@
+# 0004 — Achromatopsia via BT.709 photopic luminance (not BT.601, not LMS)
+
+## Status
+
+Accepted.
+
+## Context
+
+`achromatopsia` (total color blindness) simulates a viewer with non-functional
+cones, who perceives only luminance — the image collapses to grayscale.
+
+Two sub-questions arise:
+
+1. Can the Machado matrix path (ADR-0001) be reused? Achromatopsia is a *cone
+   dysfunction*, so cone tristimulus values do not apply — the LMS / cone-matrix
+   framing breaks down.
+2. Which luminance coefficients produce the grayscale value? The two common
+   choices are BT.709 (`0.2126 / 0.7152 / 0.0722`) and BT.601 NTSC luma
+   (`0.299 / 0.587 / 0.114`).
+
+## Decision
+
+Treat `achromatopsia` as a **separate path** from the dichromacy matrices.
+Compute the **CIE photopic luminance using BT.709 coefficients in linear sRGB**:
+
+```
+Y = 0.2126·R + 0.7152·G + 0.0722·B      (R, G, B linear)
+```
+
+and blend each channel toward `(Y, Y, Y)` with `strength` in linear space
+(ADR-0002). Do **not** use BT.601 luma, and do **not** route through an LMS /
+cone matrix.
+
+## Alternatives considered
+
+1. **Reuse a Machado-style cone matrix** for achromatopsia.
+2. **BT.601 luma** (`0.299 / 0.587 / 0.114`) for the grayscale value.
+3. **BT.709 photopic luminance** in linear sRGB (chosen).
+
+## Rationale
+
+- The cones are dysfunctional, so the tristimulus (LMS / cone-matrix) premise
+  does not hold; there is no meaningful cone transform to apply. A dedicated
+  luminance-collapse path is the honest model (alternative 1 rejected).
+- `0.2126 / 0.7152 / 0.0722` are the **BT.709 / sRGB primaries' CIE Y weights** —
+  the correct luminance for sRGB content. BT.601's `0.299 / 0.587 / 0.114` are
+  *NTSC CRT* luma weights and are wrong for sRGB / linear content (alternative 2
+  rejected).
+- Computing `Y` in **linear** sRGB (not gamma space) is consistent with every
+  other filter (ADR-0001) and is required for a photometrically correct
+  luminance.
+
+## Consequences / Trade-offs
+
+- **Gain:** a correct grayscale luminance for sRGB content; `R == G == B` at
+  `strength = 1.0`; white→white and black→black hold exactly.
+- **Gain:** the same BT.709 coefficients are reused as `LUMA_R/G/B` across other
+  luminance-based filters (e.g. `photophobia`, `starbursts`, `nyctalopia`'s
+  photopic term), so there is one luminance convention in the crate.
+- **Cost:** achromatopsia does not share the matrix code path, so it is a
+  separate function and a separate KAT (`golden_achromatopsia_strength1`,
+  `cross_check_achromatopsia`).
+- **Cost:** photopic luminance models cone-mediated daylight vision; true
+  achromats rely on rod (scotopic) vision, which has a different spectral
+  weighting. We deliberately model the *appearance* (a luminance-only image),
+  not the rod spectral sensitivity. (Scotopic weighting is used separately by
+  `nyctalopia`; see `crates/core/tests/color_kat.rs`.)
+
+## References
+
+- `docs/overview.md` — "Color vision algorithm": *the filter computes the CIE
+  photopic luminance Y = 0.2126·R + 0.7152·G + 0.0722·B (BT.709 primaries,
+  linear) … BT.601 luma … is not used*.
+- `crates/core/src/vision.rs` — module docstring (`## achromatopsia`,
+  `BT.601 … は使わない`); `LUMA_R` / `LUMA_G` / `LUMA_B` consts; `achromatopsia`.
+- `CLAUDE.md` — "主要な設計判断": *achromatopsia だけは LMS 経路を捨てて
+  BT.709 photopic luminance（NTSC 用 BT.601 ではない）でグレースケール化する*.
+- [`matrix-provenance.md`](matrix-provenance.md) — provenance of the BT.709
+  coefficients.

--- a/docs/adr/0005-phased-scope-phase1-four-types.md
+++ b/docs/adr/0005-phased-scope-phase1-four-types.md
@@ -1,0 +1,78 @@
+# 0005 — Phased scope: Phase 1 limited to the four dichromacy / achromatopsia types
+
+## Status
+
+Accepted.
+
+## Context
+
+`sensus` ultimately covers a large surface of vision and hearing conditions
+(the `roadmap.md` table spans Phases 0–6). Building everything at once risks
+shipping a wide but shallow, hard-to-verify codebase.
+
+A starting point had to be chosen. The candidate first cut for the `vision`
+module was the color-vision conditions.
+
+## Decision
+
+Scope **Phase 1** (Issue #2) to exactly four color-vision types:
+
+- `protanopia`
+- `deuteranopia`
+- `tritanopia`
+- `achromatopsia`
+
+Later perceptual categories (tetrachromacy, refraction, visual-field defects,
+light/transparency, motion, hearing, stereo, shaders) are deferred to their own
+later phases, each tracked by its own Issue in `roadmap.md`.
+
+## Alternatives considered
+
+1. **Implement the whole vision module at once** (all field defects, refraction,
+   light, motion together).
+2. **Start with refraction / blur** instead of color vision.
+3. **Start with the four color-vision types** (chosen).
+
+## Rationale
+
+- The four color-vision types rest on a **published, peer-reviewed source with
+  citable numeric values** — the Machado 2009 severity-1.0 matrices for the
+  three dichromacies and the BT.709 luminance weights for achromatopsia
+  (ADR-0001, ADR-0004, [`matrix-provenance.md`](matrix-provenance.md)). That
+  makes them the most *verifiable* starting point: the output can be checked
+  against an external reference rather than against the project's own opinion.
+- That verifiability is concrete: the four types are exactly the ones pinned by
+  the source-value known-answer tests (`crates/core/tests/color_kat.rs` covers
+  protanopia / deuteranopia / tritanopia / achromatopsia). A first phase whose
+  correctness can be asserted against the literature establishes the gamma /
+  matrix / blend pipeline that later linear-sRGB filters reuse.
+- Tetrachromacy was *not* included in this first cut precisely because it is
+  **not** physically derivable from RGB input — it is an illustrative
+  visualization, not a source-anchored simulation — so it belongs in a separate
+  phase (Phase 1+, #3) with a clearly different fidelity claim.
+
+## Consequences / Trade-offs
+
+- **Gain:** a small, fully source-verifiable first deliverable that lays down
+  the linear-sRGB gamma/matrix/blend foundation reused by every later vision
+  filter.
+- **Gain:** each subsequent category gets its own Issue and phase, so scope and
+  fidelity claims stay legible per `roadmap.md`.
+- **Cost:** the crate was not "feature complete" for vision at the end of
+  Phase 1; consumers had to wait for later phases for blur, field defects, etc.
+- **Cost:** the phased boundary is a project-management line, not a perceptual
+  one — some users think of "color blindness" and "blurry vision" together, but
+  they shipped in different phases.
+
+## References
+
+- `docs/roadmap.md` — phase table: Phase 1 = 色覚特性
+  (protanopia / deuteranopia / tritanopia / achromatopsia), #2; tetrachromacy is
+  a separate Phase 1+, #3.
+- `crates/core/src/vision.rs` — module docstring: *Phase 1 (Issue #2) では色覚
+  特性 4 種を実装する*.
+- `docs/overview.md` — "Color vision algorithm (Phase 1, #2)" and "Tetrachromacy
+  algorithm (Phase 1+, #3)" (the *Fundamental limitation*: a physically exact
+  tetrachromat simulation is impossible from RGB input).
+- `crates/core/tests/color_kat.rs` — source-value KAT covers exactly these four
+  types.

--- a/docs/adr/0006-filters-as-pure-functions-explicit-seed.md
+++ b/docs/adr/0006-filters-as-pure-functions-explicit-seed.md
@@ -1,0 +1,69 @@
+# 0006 — Filters are pure functions with an explicit seed
+
+## Status
+
+Accepted.
+
+## Context
+
+`sensus-core` filters are applied not only to single still images but, for
+video, **per frame** by the caller (the same per-frame API in a loop). Some
+filters need randomness — floaters / vitreous opacities, scatter noise,
+flickering stars — which naturally invites internal RNG state.
+
+The crate also has a hard architectural line: `sensus-core` is pure logic with
+no filesystem, no subprocesses, no GUI (all host I/O lives in the `sensus` CLI
+crate).
+
+## Decision
+
+Every filter is a **pure function over pixel/audio buffers**: it does not
+consult the filesystem, does not spawn subprocesses, and carries **no internal
+RNG state** that drifts between calls. Filters that need randomness take an
+**explicit `seed` parameter**, so successive frames are reproducible and
+coherent. `strength` is always normalized to `0.0..=1.0` (`0.0` = identity).
+
+## Alternatives considered
+
+1. **Internal/global RNG state** in each randomized filter (e.g. a thread-local
+   or filter-owned PRNG advanced on each call).
+2. **Pure functions with an explicit seed argument** (chosen).
+
+## Rationale
+
+- Per-frame video application requires **determinism**: with internal RNG state,
+  successive frames would draw different noise and the random elements (floaters,
+  stars) would flicker incoherently between frames. An explicit seed lets the
+  caller hold the seed constant across a clip so the random pattern stays stable
+  (alternative 1 rejected).
+- Purity keeps `sensus-core` testable and side-effect-free, matching the
+  crate-layout rule that all I/O is isolated in the CLI crate. Pure functions
+  are also what the GLSL shader path can mirror exactly (a fragment shader has
+  no scan-order state) — e.g. the `dry_eye` per-tile *spatial hash* replaced an
+  order-dependent sequential LCG precisely so a parallel shader could reproduce
+  it.
+- Normalizing `strength` to `0.0..=1.0` with `0.0` = identity gives every filter
+  a uniform, predictable contract for callers and tests.
+
+## Consequences / Trade-offs
+
+- **Gain:** deterministic, reproducible output; coherent video; CPU and GLSL
+  paths can be held equivalent; trivial unit testing (same input → same output).
+- **Gain:** clean dependency story — no RNG crate state to manage, no hidden
+  global state.
+- **Cost:** callers must thread a `seed` (and other params) through every call;
+  the API is slightly more verbose than a "just blur it" one-arg call.
+- **Cost:** "more random-looking" effects that would benefit from genuine
+  per-frame entropy are not available by default — but the caller can vary the
+  seed deliberately if they want that.
+
+## References
+
+- `docs/overview.md` — "I/O contract": *Filters do not consult the filesystem …
+  They are pure functions over pixel buffers … must therefore be deterministic …
+  accept an explicit seed parameter so successive frames stay coherent*.
+- `docs/overview.md` — "Eye Fatigue filters" (`dry_eye` spatial-hash rationale:
+  the earlier sequential-LCG noise could not be reproduced by a parallel
+  fragment shader).
+- `CLAUDE.md` — "主要な設計判断": *フィルタは純粋関数 … 乱数が必要な場合は
+  `seed` パラメータを明示的に受け取る*; *`strength` は 0.0..=1.0 に正規化*.

--- a/docs/adr/0007-wasm-out-of-scope.md
+++ b/docs/adr/0007-wasm-out-of-scope.md
@@ -1,0 +1,52 @@
+# 0007 — WebAssembly is out of scope
+
+## Status
+
+Accepted.
+
+## Context
+
+A perceptual-filter library is an obvious candidate for a browser/WebAssembly
+build — it would let web frontends run the simulations client-side. Supporting
+`wasm32` would, however, pull in web-specific concerns (e.g. a `getrandom`
+backend and other target-conditional dependencies) and an additional build/CI
+matrix to maintain.
+
+## Decision
+
+**WebAssembly is not a target.** `sensus` does not ship a wasm build and does
+not take on `wasm32`-specific dependencies. Web frontends are out of scope.
+
+## Alternatives considered
+
+1. **Add a `wasm32` target** with the necessary web-specific dependencies and a
+   wasm CI lane.
+2. **No wasm target** (chosen).
+
+## Rationale
+
+- The primary (and prominent) consumer is
+  [universal-experience](https://github.com/kako-jun/universal-experience), a
+  **native Flutter app** that links `sensus-core` directly. There is no current
+  web consumer.
+- A wasm build adds maintenance cost — extra dependencies (e.g. a wasm
+  `getrandom` backend) and an extra build/test matrix — **without a clear
+  consumer** to justify it. The decision keeps the dependency surface small and
+  the CI matrix native-only.
+
+## Consequences / Trade-offs
+
+- **Gain:** smaller dependency surface, simpler CI, no target-conditional code
+  paths for randomness or I/O.
+- **Cost:** a future web frontend cannot reuse `sensus-core` in-browser without
+  first reversing this decision (which would be a new ADR superseding this one).
+- **Cost:** none for the current native consumer, which is the only one that
+  exists.
+
+## References
+
+- `docs/overview.md` — "Crate layout" (*WebAssembly is not a target … Web
+  frontends are out of scope*) and "Out of scope / Non-goals" (*a wasm build
+  adds maintenance cost without a clear consumer*).
+- `CLAUDE.md` — "主要な設計判断": *WASM ターゲットは持たない … wasm32 用の
+  getrandom 等の追加依存は避ける*.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,58 @@
+# Architecture Decision Records (ADR)
+
+This directory is the **canonical record** of the significant design decisions
+behind `sensus`. An ADR captures *why* a choice was made — the problem, the
+alternatives that were weighed, the reasoning, and the trade-offs we accepted —
+so that downstream consumers
+([universal-experience](https://github.com/kako-jun/universal-experience)) and
+future contributors can audit the rationale rather than reverse-engineering it
+from the code.
+
+`sensus` is the upstream source of truth for the perceptual simulation math.
+Before this directory existed, the design rationale was scattered across
+`CLAUDE.md` notes, `docs/overview.md` prose, and derivation comments in
+`crates/core/src/vision.rs`. The ADRs here promote that scattered reasoning into
+formal, dated, individually-citable records. The scattered prose remains as a
+quick summary; **the ADRs are authoritative when they disagree.**
+
+## What an ADR is
+
+Each ADR is a short Markdown file describing **one** decision. We follow a
+[MADR](https://adr.github.io/madr/)-style template, kept deliberately lean.
+Every ADR has these sections:
+
+- **Status** — `Accepted`, `Superseded by NNNN`, or `Proposed`.
+- **Context** — the problem and the forces at play (what made a decision
+  necessary).
+- **Decision** — the choice that was made, stated plainly.
+- **Alternatives considered** — the options that were on the table.
+- **Rationale** — why the chosen option won over the alternatives.
+- **Consequences / Trade-offs** — what we gain and what we give up by accepting
+  this decision.
+
+## Numbering convention
+
+- ADRs are numbered sequentially with a zero-padded four-digit prefix:
+  `0001-`, `0002-`, … followed by a short kebab-case slug.
+- Numbers are **never reused**. A decision that overturns an earlier one gets a
+  new number and marks the old ADR `Superseded by NNNN`; the old file is kept
+  for the historical record.
+- New ADRs append to the end of the table below.
+
+## Index
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-linear-srgb-machado-matrices.md) | Operate color-vision simulation in linear sRGB, applying Machado 2009 matrices directly (no explicit LMS pipeline) | Accepted |
+| [0002](0002-linear-blend-intermediate-severity.md) | Linear blend for intermediate severity | Accepted |
+| [0003](0003-disk-blur-not-gaussian.md) | Disk (pillbox) blur for defocus / refraction, not Gaussian | Accepted |
+| [0004](0004-achromatopsia-bt709-photopic.md) | Achromatopsia via BT.709 photopic luminance (not BT.601, not LMS) | Accepted |
+| [0005](0005-phased-scope-phase1-four-types.md) | Phased scope: Phase 1 limited to the four dichromacy / achromatopsia types | Accepted |
+| [0006](0006-filters-as-pure-functions-explicit-seed.md) | Filters are pure functions with an explicit seed | Accepted |
+| [0007](0007-wasm-out-of-scope.md) | WebAssembly is out of scope | Accepted |
+
+## Related specifications
+
+- [`matrix-provenance.md`](matrix-provenance.md) — provenance of the color-vision
+  matrices and luminance coefficients: which source, which cells, how extracted,
+  and how the values are pinned by tests. Read alongside ADR-0001 and ADR-0004.

--- a/docs/adr/matrix-provenance.md
+++ b/docs/adr/matrix-provenance.md
@@ -1,0 +1,179 @@
+# Matrix provenance specification
+
+This document records the **provenance** of every numeric color-vision constant
+baked into `sensus-core`: which published source it came from, *which cells* were
+taken, *how* they were extracted, the tie-break rule when sources disagree, and
+*how the values are pinned by tests*. It exists so that any future proposal to
+change a matrix can be audited — and so a downstream consumer can trace a number
+back to its origin.
+
+Read this alongside [ADR-0001](0001-linear-srgb-machado-matrices.md) (why the
+matrices are applied directly in linear sRGB) and
+[ADR-0004](0004-achromatopsia-bt709-photopic.md) (the achromatopsia luminance
+path).
+
+## Scope
+
+| Constant (in `crates/core/src/vision.rs`) | Kind | Source |
+|---|---|---|
+| `PROTANOPIA` | 3×3 CVD matrix, severity = 1.0 | Machado 2009 |
+| `DEUTERANOPIA` | 3×3 CVD matrix, severity = 1.0 | Machado 2009 |
+| `TRITANOPIA` | 3×3 CVD matrix, severity = 1.0 | Machado 2009 |
+| `LUMA_R` / `LUMA_G` / `LUMA_B` | photopic luminance weights | ITU-R BT.709 / sRGB (CIE Y) |
+
+## 1. The dichromacy matrices (Machado 2009)
+
+### Source
+
+Machado, Oliveira & Fernandes (2009), **"A Physiologically-based Model for
+Simulation of Color Vision Deficiency"**, *IEEE Transactions on Visualization
+and Computer Graphics (TVCG)*.
+DOI: [10.1109/TVCG.2009.113](https://doi.org/10.1109/TVCG.2009.113).
+
+Public mirrors of the same numeric values:
+
+- Author's supplementary page:
+  <https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html>
+- DaltonLens project: <https://daltonlens.org/>
+
+### Which cells
+
+The **severity = 1.0** (full dichromacy) pre-computed matrices, one per
+deficiency. Each is the `3×3` operator that maps **linear sRGB → simulated
+linear sRGB** (the cone-space physiology is already pre-multiplied into this
+matrix — see ADR-0001; there is no separate LMS step).
+
+These are the exact values currently in `crates/core/src/vision.rs`:
+
+**`PROTANOPIA`** (type-1, L-cone deficiency)
+
+```
+[ 0.152286,  1.052583, -0.204868 ]
+[ 0.114503,  0.786281,  0.099216 ]
+[-0.003882, -0.048116,  1.051998 ]
+```
+
+**`DEUTERANOPIA`** (type-2, M-cone deficiency)
+
+```
+[ 0.367322,  0.860646, -0.227968 ]
+[ 0.280085,  0.672501,  0.047413 ]
+[-0.011820,  0.042940,  0.968881 ]
+```
+
+**`TRITANOPIA`** (type-3, S-cone deficiency)
+
+```
+[ 1.255528, -0.076749, -0.178779 ]
+[-0.078411,  0.930809,  0.147602 ]
+[ 0.004733,  0.691367,  0.303900 ]
+```
+
+> The crate stores these as `f32`; the literals above are reproduced exactly as
+> written in the source const (and re-typed independently in the test — see
+> §3). Row order is `[R_out; G_out; B_out]`, column order is `[R_in, G_in,
+> B_in]`, i.e. `out = M · in` per pixel in linear sRGB.
+
+### How extracted
+
+The published severity-1.0 matrices were taken **verbatim** — no re-derivation,
+no re-fit, no re-scaling. Because Machado et al. already pre-multiplied the
+cone physiology into a linear-sRGB→linear-sRGB matrix, the extraction is simply
+"copy the published severity-1.0 table". The application pipeline around them is
+documented in ADR-0001 and ADR-0002.
+
+### Tie-break rule when sources disagree
+
+The published paper, the author's supplementary page, and the DaltonLens public
+data **carry identical values**, so no tie-break was required for the current
+matrices. The standing rule, should a future source disagree:
+
+1. The **IEEE TVCG paper / author's supplementary page is the primary source.**
+   If a redistributor's value differs, the original takes precedence.
+2. Any discrepancy must be resolved *before* changing a const, and the chosen
+   value and the reason must be recorded in this spec (and, if it changes the
+   decision, an ADR).
+
+## 2. The luminance coefficients (BT.709 / sRGB)
+
+### Source
+
+ITU-R Recommendation **BT.709** luma / sRGB primaries' CIE Y weights:
+
+```
+LUMA_R = 0.2126
+LUMA_G = 0.7152
+LUMA_B = 0.0722
+```
+
+### Which cells / why these
+
+These are the photopic luminance (CIE Y) weights for the BT.709 / sRGB
+primaries. They are used by `achromatopsia` to collapse a pixel to grayscale
+(ADR-0004) and are shared by other luminance-based filters (`photophobia`,
+`starbursts`, the photopic term of `nyctalopia`).
+
+**BT.601** luma (`0.299 / 0.587 / 0.114`, NTSC CRT) is deliberately **not**
+used: those weights are wrong for sRGB / linear content. This rejection is part
+of ADR-0004.
+
+### How extracted
+
+Standard published constants, copied verbatim from the BT.709 / sRGB
+specification.
+
+## 3. How these values are verified (pinning)
+
+The constants above are pinned against the source by a known-answer test (KAT),
+introduced in **#156**: `crates/core/tests/color_kat.rs`.
+
+The KAT is deliberately built to avoid tautology — it does **not** import the
+`vision.rs` consts:
+
+- The source matrices are **re-typed as independent literals** in the test
+  (`SRC_PROTANOPIA` / `SRC_DEUTERANOPIA` / `SRC_TRITANOPIA`) with the DOI in a
+  comment. These are a physically separate copy of the published values, so if
+  the `vision.rs` const drifts, the test's expectation and the implementation's
+  output diverge and the KAT fails.
+- The BT.709 weights are likewise re-typed independently (`BT709` in the test).
+- The gamma round-trip, matrix multiply, blend, and 8-bit packing are
+  **re-implemented inside the test** (a reference pipeline), so the test does
+  not call any `vision.rs` private function.
+- A handful of cases are additionally pinned with **offline-computed golden u8
+  literals** (`golden_*` tests, exact equality), catching pipeline regressions
+  as well as matrix drift.
+
+**Sensitivity, stated honestly:** the KAT verifies the **8-bit quantized
+output**. It catches any matrix drift large enough to move a rounded output
+channel by `1/255` (golden anchors use exact equality; non-saturated mid-tone
+inputs surface coefficient changes of roughly `0.001–0.004`). Sub-`u8`
+floating-point drift that leaves every rounded channel unchanged is **out of
+scope by design** — the intrinsic limit of an 8-bit-output check.
+
+## 4. Procedure for changing a matrix (auditable improvement path)
+
+A future proposal to change any value in this spec **must**:
+
+1. Identify the new source and cite it (DOI / URL), and apply the tie-break rule
+   in §1 if it disagrees with the existing source.
+2. Update the const in `crates/core/src/vision.rs` **and** its derivation
+   comment.
+3. Update this spec (the value table, the source, and the tie-break note).
+4. Update the **independent** literal copy in `crates/core/tests/color_kat.rs`
+   (`SRC_*` / `BT709`) and recompute the affected `golden_*` u8 anchors offline.
+5. If the change alters a *decision* (not just a value), add or supersede an ADR.
+
+Because the implementation const and the test literal are independent copies,
+step 2 without step 4 will make the KAT fail — which is exactly the guardrail
+that keeps this spec, the code, and the tests in agreement.
+
+## References
+
+- `crates/core/src/vision.rs` — `PROTANOPIA` / `DEUTERANOPIA` / `TRITANOPIA` /
+  `LUMA_R/G/B` consts and their derivation comments.
+- `crates/core/tests/color_kat.rs` — `SRC_*`, `BT709`, reference pipeline,
+  `golden_*`, and `cross_check_*` tests.
+- `docs/overview.md` — "Color vision algorithm (Phase 1, #2)" and "GLSL ES 3.00
+  shader source API" (the source-consistency vs self-consistency distinction).
+- [ADR-0001](0001-linear-srgb-machado-matrices.md),
+  [ADR-0004](0004-achromatopsia-bt709-photopic.md).

--- a/docs/adr/matrix-provenance.md
+++ b/docs/adr/matrix-provenance.md
@@ -30,11 +30,12 @@ Simulation of Color Vision Deficiency"**, *IEEE Transactions on Visualization
 and Computer Graphics (TVCG)*.
 DOI: [10.1109/TVCG.2009.113](https://doi.org/10.1109/TVCG.2009.113).
 
-Public mirrors of the same numeric values:
+Corroborating references:
 
-- Author's supplementary page:
+- Author's supplementary page (carries the same severity-1.0 matrices verbatim):
   <https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html>
-- DaltonLens project: <https://daltonlens.org/>
+- DaltonLens project (independent analysis / reimplementation of the
+  Machado-family model; corroborates the values): <https://daltonlens.org/>
 
 ### Which cells
 
@@ -84,9 +85,9 @@ documented in ADR-0001 and ADR-0002.
 
 ### Tie-break rule when sources disagree
 
-The published paper, the author's supplementary page, and the DaltonLens public
-data **carry identical values**, so no tie-break was required for the current
-matrices. The standing rule, should a future source disagree:
+The published paper and the author's supplementary page **carry identical
+values**, and the DaltonLens analysis corroborates them, so no tie-break was
+required for the current matrices. The standing rule, should a future source disagree:
 
 1. The **IEEE TVCG paper / author's supplementary page is the primary source.**
    If a redistributor's value differs, the original takes precedence.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -211,6 +211,14 @@ Color vision deficiency simulation uses the
   sRGB content.
 - Preserves the alpha channel.
 
+The rationale for these choices (linear sRGB, direct Machado matrices, linear
+blend, BT.709 photopic luminance) is recorded canonically in
+[`adr/`](adr/) — see [ADR-0001](adr/0001-linear-srgb-machado-matrices.md),
+[ADR-0002](adr/0002-linear-blend-intermediate-severity.md), and
+[ADR-0004](adr/0004-achromatopsia-bt709-photopic.md). The provenance of the
+matrices and luminance coefficients is in
+[`adr/matrix-provenance.md`](adr/matrix-provenance.md).
+
 [machado]: https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html
 [doi]: https://doi.org/10.1109/TVCG.2009.113
 
@@ -256,7 +264,9 @@ defocus using a **disk (pillbox) blur** in linear sRGB space:
   the aperture, so the impulse response of a defocused eye is the shape
   of the pupil — a uniform-density disk to first approximation. Gaussian
   blur is a good *de-noising* prior but is **not** what a defocused eye
-  produces; sensus uses disk blur for physical correctness.
+  produces; sensus uses disk blur for physical correctness. The rationale is
+  recorded canonically in
+  [ADR-0003](adr/0003-disk-blur-not-gaussian.md).
 - All four filters operate in **linear sRGB** (decode → blur → re-encode).
   Convolving gamma-encoded sRGB darkens midtones and is wrong.
 - Alpha is preserved (the filter affects color only).


### PR DESCRIPTION
## 関連 Issue
closes #158

## 背景
正本リポなのに設計判断・行列の出自が formal に記録されておらず CLAUDE.md のメモに散在。下流/将来の contributor が「なぜこの仕様か」を追えなかった。

## 変更内容（docs のみ・コード非変更）
`docs/adr/` を新設し、散在していた設計判断を ADR（Status / Context / Decision / Alternatives / Rationale / Consequences）へ昇格。

- `README.md`（ADR 採番規約・index・MADR 風 template）
- `0001` linear sRGB で Machado 2009 行列を直接適用（LMS 経路を組まない）
- `0002` 中間 severity の linear blend
- `0003` disk(pillbox) blur 採用・Gaussian 不採用（circle of confusion = 瞳孔の一様円投影）
- `0004` achromatopsia は BT.709 photopic luminance（BT.601 でも LMS でもない）
- `0005` phase 設計：Phase 1 を4色覚に限定（出典確度・KAT 検証可能性）
- `0006` filters = pure functions + 明示 seed（フレーム間決定性）
- `0007` WASM 非対象

`docs/adr/matrix-provenance.md`（行列出自 spec）：PROTANOPIA/DEUTERANOPIA/TRITANOPIA（全9セル）と BT.709 LUMA 係数の **出典（Machado 2009, DOI:10.1109/TVCG.2009.113 / DaltonLens）・抽出方法（verbatim）・出典相違時の選定基準・将来変更手順**を記録。値は vision.rs の実 const と完全一致を確認。これらが `tests/color_kat.rs` の独立リテラル + golden KAT で固定されている（#156）旨を相互参照。

既存 docs への追記は最小限（overview にポインタ・CLAUDE に「ADR が正本」1行）。各 ADR の Rationale は overview.md / vision.rs / CLAUDE.md / roadmap.md の既述に接地し、理由の捏造なし。