### PR TITLE
docs: コメント・出典表記の是正バッチ（myopia比率 / tetrachromacy provenance / cataract 再解釈）

### DIFF
--- a/crates/core/src/shaders/cataract.frag
+++ b/crates/core/src/shaders/cataract.frag
@@ -90,9 +90,11 @@ void main() {
     float ng = g + (yg - g) * uStrength;
     float nb = b + (yb - b) * uStrength;
 
-    // VIP-Sim 二段モデルの輝度・コントラスト低下（#106）。
+    // VIP-Sim 二段モデルの**再解釈**による輝度・コントラスト低下（#106）。
     // pivot 0.5 中心の per-channel コントラスト収縮（ContrastCoeff = 0.7, 0.7, 0.4）
-    // + 輝度低下。CPU vision::cataract と同一演算。
+    // + 輝度低下。CPU vision::cataract と同一演算。原典 VIP-Sim との差分（原典は
+    // brightness ×(1-severity) の乗算・pivot=ContrastCoeff 自身）は CPU 側
+    // `vision::cataract` の doc コメント参照（#170）。
     const float PIVOT = 0.5;
     const float BRIGHTNESS_DROP = 0.1;
     nr = clamp((nr - PIVOT) * (1.0 - uStrength * (1.0 - 0.7)) + PIVOT - uStrength * BRIGHTNESS_DROP, 0.0, 1.0);

--- a/crates/core/src/shaders/tetrachromacy.frag
+++ b/crates/core/src/shaders/tetrachromacy.frag
@@ -2,11 +2,13 @@
 precision mediump float;
 
 // 四色型色覚（Tetrachromacy）シミュレーション。
-// LMS 変換 + 赤-緑 opponent channel 誇張。
-// CPU 実装 vision::tetrachromacy に対応。
+// 疑似 LMS 変換 + 赤-緑 opponent channel 誇張。
+// CPU 実装 vision::tetrachromacy と同じ |delta| < 0.05 メタメリック分岐を持つ
+// （CPU/GPU で分岐ロジックは同一。数値の丸め差はあり得るが簡略化ではない）。
 //
-// メタメリックペア候補領域（|delta| < 0.05）の Cb/Cr 誇張は、
-// GPU では閾値判定が難しいため全領域に opponent channel 誇張を適用する簡略版。
+// 測色的忠実度を主張しない可視化演出であり、L/M 相当値も真の錐体刺激値では
+// ないヒューリスティックな代理量。詳細は CPU 側 vision::tetrachromacy の
+// doc コメントと docs/adr/matrix-provenance.md の Heuristic matrices 節を参照。
 
 uniform sampler2D uTexture;
 uniform float uStrength;
@@ -27,7 +29,9 @@ void main() {
     float g = srgbToLinear(orig.g);
     float b = srgbToLinear(orig.b);
 
-    // Machado 2009 linear sRGB → LMS 変換行列の第1-2行
+    // Hunt-Pointer-Estévez (HPE) XYZ→LMS 変換行列（D65）を linear RGB に直接
+    // 流用したヒューリスティックの第1-2行（Machado 2009 由来ではない。
+    // CPU 側 HPE_LMS_HEURISTIC と同一数値 — 数値は変更していない）
     float lCone = 0.4002 * r + 0.7076 * g + (-0.0808) * b;
     float mCone = (-0.2263) * r + 1.1653 * g + 0.0457 * b;
 

--- a/crates/core/src/vision/color.rs
+++ b/crates/core/src/vision/color.rs
@@ -148,11 +148,17 @@ fn apply_machado_matrix(
 /// ペア候補）を検出し、その領域の Cb/Cr 色差を追加誇張する。
 /// 全領域には赤-緑 opponent channel の基本誇張も適用する。
 ///
-/// ## アルゴリズム（Machado 2009 LMS 変換使用）
+/// 本フィルタは測色的忠実度を主張しない可視化演出であり、メタメリックペア候補の
+/// 検出に使う L/M 値も真の錐体刺激値ではなくヒューリスティックな代理量である
+/// （詳細は `HPE_LMS_HEURISTIC` の doc コメントと
+/// `docs/adr/matrix-provenance.md` の Heuristic matrices 節を参照）。
+///
+/// ## アルゴリズム（Hunt-Pointer-Estévez 行列を linear RGB に直接流用するヒューリスティック）
 ///
 /// 1. linear sRGB に変換（gamma 解除）
-/// 2. linear sRGB → LMS（Machado 2009 の変換行列）
-/// 3. M（緑錐体）と L（赤錐体）の差分 `delta = M - L` を抽出
+/// 2. linear sRGB → 疑似 LMS（Hunt-Pointer-Estévez の XYZ→LMS 変換行列を、
+///    sRGB→XYZ を挟まず linear RGB に直接適用するヒューリスティック）
+/// 3. M（緑錐体相当）と L（赤錐体相当）の差分 `delta = M - L` を抽出
 /// 4. `|delta| < 0.05` の領域 = メタメリックペア候補
 /// 5. そのような領域で Cb/Cr（色差）を `strength * 2.0` 倍に誇張
 /// 6. 全領域: 赤-緑 opponent channel を基本誇張（strength でスケール）
@@ -168,10 +174,18 @@ pub fn tetrachromacy(img: DynamicImage, strength: f32) -> crate::Result<DynamicI
         return Ok(DynamicImage::ImageRgba8(rgba));
     }
 
-    // Machado 2009 linear sRGB → LMS 変換行列
-    // 出典: Machado, Oliveira, Fernandes 2009, Equation 1 / Table 1
-    // (Hunt-Pointer-Estévez の D65 白色点正規化版)
-    const SRGB_TO_LMS: [[f32; 3]; 3] = [
+    // Hunt-Pointer-Estévez (HPE) の CIE XYZ→LMS 変換行列（D65 白色点正規化版）。
+    //
+    // この行列は Machado, Oliveira & Fernandes (2009) の Table 1 には存在しない
+    // （同 Table 1 が公開するのは severity=1.0 の CVD 行列 3 種のみ。
+    // `docs/adr/matrix-provenance.md` §1 参照）。かつ本来 HPE 行列は CIE XYZ
+    // 入力を前提とするが、ここでは sRGB→XYZ 変換を挟まず linear RGB に直接
+    // 適用しているためヒューリスティックであり、測色的な LMS 値ではない。
+    //
+    // tetrachromacy はメタメリック検出の可視化演出であり、測色的忠実度を
+    // 主張しない。出典・スコープの詳細は
+    // `docs/adr/matrix-provenance.md` の "Heuristic matrices" 節を参照（#170）。
+    const HPE_LMS_HEURISTIC: [[f32; 3]; 3] = [
         [0.4002, 0.7076, -0.0808],
         [-0.2263, 1.1653, 0.0457],
         [0.0000, 0.0000, 0.9182],
@@ -185,9 +199,11 @@ pub fn tetrachromacy(img: DynamicImage, strength: f32) -> crate::Result<DynamicI
         let g = srgb_to_linear(px[1] as f32 / 255.0);
         let b = srgb_to_linear(px[2] as f32 / 255.0);
 
-        // linear sRGB → LMS
-        let l_cone = SRGB_TO_LMS[0][0] * r + SRGB_TO_LMS[0][1] * g + SRGB_TO_LMS[0][2] * b;
-        let m_cone = SRGB_TO_LMS[1][0] * r + SRGB_TO_LMS[1][1] * g + SRGB_TO_LMS[1][2] * b;
+        // linear RGB → 疑似 LMS（HPE ヒューリスティック、上記 doc コメント参照）
+        let l_cone =
+            HPE_LMS_HEURISTIC[0][0] * r + HPE_LMS_HEURISTIC[0][1] * g + HPE_LMS_HEURISTIC[0][2] * b;
+        let m_cone =
+            HPE_LMS_HEURISTIC[1][0] * r + HPE_LMS_HEURISTIC[1][1] * g + HPE_LMS_HEURISTIC[1][2] * b;
 
         // M と L の差分（メタメリズム指標）
         let delta = m_cone - l_cone;

--- a/crates/core/src/vision/light.rs
+++ b/crates/core/src/vision/light.rs
@@ -55,7 +55,8 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
     // 原典 VIP-Sim（一次出典 `myBrightnessContrastGamma.shader`:
     // `color *= _BCG.x; color = (color - coeff) * _BCG.y + coeff`）は
     // brightness を `×(1-severity)` の乗算（severity=1 で全消灯）とし、
-    // コントラスト pivot は ContrastCoeff そのもの (0.7, 0.7, 0.4) を使う。
+    // コントラスト pivot は ContrastCoeff そのもの (0.7, 0.7, 0.4) を使う
+    // （B 係数 0.4 が最小＝白内障で青の散乱が最大であることに対応する）。
     // sensus はこれと異なり pivot を 0.5 に固定し、輝度低下も
     // `-0.1*severity` の減算オフセットとする——原典よりずっとマイルドな
     // 実装であり、原典の忠実移植ではない（挙動は本修正で変更しない。

--- a/crates/core/src/vision/light.rs
+++ b/crates/core/src/vision/light.rs
@@ -59,7 +59,7 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
     // sensus はこれと異なり pivot を 0.5 に固定し、輝度低下も
     // `-0.1*severity` の減算オフセットとする——原典よりずっとマイルドな
     // 実装であり、原典の忠実移植ではない（挙動は本修正で変更しない。
-    // 挙動変更の提案は #171 で別管理）。
+    // 挙動変更の提案は #174 で別管理）。
     const CATARACT_PIVOT: f32 = 0.5;
     const CATARACT_BRIGHTNESS_DROP: f32 = 0.1;
 
@@ -146,17 +146,10 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
             let nb = b + (yb - b) * strength;
 
             // VIP-Sim 二段モデルの**再解釈**（#106）: severity 比例の輝度・コントラスト低下。
-            // 白内障の霞み感の核。pivot 0.5 を中心にコントラストを per-channel 収縮させ
-            // （ContrastCoeff = (0.7, 0.7, 0.4)、青の散乱が最大）、全体輝度を僅かに下げる。
-            // c_ch = 1 - s*(1 - coeff_ch) で strength=0 のとき恒等。CPU/GLSL/sim で同一演算。
-            //
-            // 原典との差分: VIP-Sim 原典（一次出典 `myBrightnessContrastGamma.shader`:
-            // `color *= _BCG.x; color = (color - coeff) * _BCG.y + coeff`）は brightness を
-            // `×(1-severity)` の乗算（severity=1 で全消灯）とし、コントラスト pivot は
-            // ContrastCoeff そのもの (0.7, 0.7, 0.4) を用いる。sensus は pivot を 0.5 に
-            // 固定し、輝度低下も `-0.1*severity` の減算オフセットとする点で原典より
-            // ずっとマイルドな再解釈である（挙動は本修正で変更しない。挙動変更の提案は
-            // #171 で別管理）。
+            // 白内障の霞み感の核。c_ch = 1 - s*(1 - coeff_ch) で strength=0 のとき恒等。
+            // CPU/GLSL/sim で同一演算。原典との差分・出典・pivot/brightness の詳細は
+            // 上記 CATARACT_PIVOT / CATARACT_BRIGHTNESS_DROP 定義のコメント参照
+            // （挙動変更の提案は #174 で別管理）。
             let nr = ((nr - CATARACT_PIVOT) * (1.0 - strength * (1.0 - 0.7)) + CATARACT_PIVOT
                 - strength * CATARACT_BRIGHTNESS_DROP)
                 .clamp(0.0, 1.0);

--- a/crates/core/src/vision/light.rs
+++ b/crates/core/src/vision/light.rs
@@ -51,7 +51,15 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
     const WHITE_BLEND_MAX: f32 = 0.4;
     // 格子セルサイズ（旧 BLOCK_SIZE=8 より大きい 32px で空間相関を確保）
     const CELL_SIZE: f32 = 32.0;
-    // VIP-Sim 二段モデルのコントラスト/輝度低下（#106）。
+    // VIP-Sim 二段モデルの**再解釈**によるコントラスト/輝度低下（#106）。
+    // 原典 VIP-Sim（一次出典 `myBrightnessContrastGamma.shader`:
+    // `color *= _BCG.x; color = (color - coeff) * _BCG.y + coeff`）は
+    // brightness を `×(1-severity)` の乗算（severity=1 で全消灯）とし、
+    // コントラスト pivot は ContrastCoeff そのもの (0.7, 0.7, 0.4) を使う。
+    // sensus はこれと異なり pivot を 0.5 に固定し、輝度低下も
+    // `-0.1*severity` の減算オフセットとする——原典よりずっとマイルドな
+    // 実装であり、原典の忠実移植ではない（挙動は本修正で変更しない。
+    // 挙動変更の提案は #171 で別管理）。
     const CATARACT_PIVOT: f32 = 0.5;
     const CATARACT_BRIGHTNESS_DROP: f32 = 0.1;
 
@@ -62,7 +70,10 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
     // spatial hash（黄金比定数混合 + XOR-shift finalizer）に置き換えた。各頂点の
     // 値は seed と頂点座標 (gx, gy) だけの決定論的関数で、逐次状態を持たない。
     // `cataract.frag` の `gridHash`（= metamorphopsia/dry_eye と同一の系列）と
-    // bit 単位に一致する（u32 演算は GLSL の uint 同様 mod 2^32 で wrap する）。
+    // 32bit 整数ハッシュ系列が bit 一致する（u32 演算は GLSL の uint 同様
+    // mod 2^32 で wrap する）。ただし最終画素値は sRGB↔linear の `pow()` が
+    // CPU/GPU で last-ULP 一致を保証されないため、完全な bit 一致は主張しない
+    // （CPU↔GLSL 等価テストは PSNR 閾値で安全側に判定する。#170）。
     let seed32 = seed as u32;
     // 1 頂点ぶんの 32bit ハッシュ（0.0..=1.0 を返す）。
     let grid_hash = |gx: u32, gy: u32| -> f32 {
@@ -134,10 +145,18 @@ pub fn cataract(img: DynamicImage, strength: f32, seed: u64) -> crate::Result<Dy
             let ng = g + (yg - g) * strength;
             let nb = b + (yb - b) * strength;
 
-            // VIP-Sim 二段モデルの未移植分（#106）: severity 比例の輝度・コントラスト低下。
+            // VIP-Sim 二段モデルの**再解釈**（#106）: severity 比例の輝度・コントラスト低下。
             // 白内障の霞み感の核。pivot 0.5 を中心にコントラストを per-channel 収縮させ
             // （ContrastCoeff = (0.7, 0.7, 0.4)、青の散乱が最大）、全体輝度を僅かに下げる。
             // c_ch = 1 - s*(1 - coeff_ch) で strength=0 のとき恒等。CPU/GLSL/sim で同一演算。
+            //
+            // 原典との差分: VIP-Sim 原典（一次出典 `myBrightnessContrastGamma.shader`:
+            // `color *= _BCG.x; color = (color - coeff) * _BCG.y + coeff`）は brightness を
+            // `×(1-severity)` の乗算（severity=1 で全消灯）とし、コントラスト pivot は
+            // ContrastCoeff そのもの (0.7, 0.7, 0.4) を用いる。sensus は pivot を 0.5 に
+            // 固定し、輝度低下も `-0.1*severity` の減算オフセットとする点で原典より
+            // ずっとマイルドな再解釈である（挙動は本修正で変更しない。挙動変更の提案は
+            // #171 で別管理）。
             let nr = ((nr - CATARACT_PIVOT) * (1.0 - strength * (1.0 - 0.7)) + CATARACT_PIVOT
                 - strength * CATARACT_BRIGHTNESS_DROP)
                 .clamp(0.0, 1.0);

--- a/crates/core/src/vision/refraction.rs
+++ b/crates/core/src/vision/refraction.rs
@@ -62,7 +62,8 @@ const ASTIGMATISM_MAX_RADIUS_RATIO: f32 = 0.011;
 
 /// Myopia (近視) シミュレーション。
 ///
-/// strength=1.0 で約 -6D 相当の defocus blur (disk 半径 ≈ 5% × min(W,H))。
+/// strength=1.0 で約 -6D 相当の defocus blur (disk 半径 ≈ 2.3% × min(W,H)、
+/// `MYOPIA_MAX_RADIUS_RATIO` の導出は同定数の doc コメント参照)。
 /// 2D 画像には深度情報がないため、本実装は画面全体の uniform blur となる
 /// (現実の myopia は遠方ほどボケが強い)。alpha は保持。
 pub fn myopia(img: DynamicImage, strength: f32) -> Result<DynamicImage> {

--- a/crates/core/tests/shader_equivalence.rs
+++ b/crates/core/tests/shader_equivalence.rs
@@ -4011,8 +4011,11 @@ fn shader_equiv_starbursts_non_square() {
 
 // ---------------------------------------------------------------------------
 // cataract（白内障）— #125 で白濁ノイズを #99 と同じ 32bit spatial hash に
-// CPU/GLSL 両方統一した。黄変マトリクス（Pokorny 1987）に加えてノイズ項も
-// CPU↔.frag↔sim が bit 一致する。
+// CPU/GLSL 両方統一した。黄変マトリクス（Pokorny 1987）に加え、ノイズ項の
+// 32bit 整数ハッシュ系列も CPU↔.frag↔sim で bit 一致する。ただし最終画素値は
+// sRGB↔linear の `pow()` が CPU/GPU で last-ULP 一致を保証されないため、
+// 完全な bit 一致は主張しない——このため以下のテストは exact 等価でなく
+// PSNR/許容差ベースで判定する（#170）。
 //
 // 旧実装（#100 時点）は CPU が 64bit Knuth LCG の高位ビット抽出
 // `(lcg >> 32)/u32::MAX`、.frag が同定数の下位 32bit 切り詰めで別系列であり、
@@ -4020,7 +4023,7 @@ fn shader_equiv_starbursts_non_square() {
 // の 0.5px オフセットで食い違っていた（PSNR 19.6dB）。#125 で:
 //   - ノイズハッシュを metamorphopsia/dry_eye と同一の 32bit spatial hash に統一
 //   - 格子規約を整数ピクセル座標 (top-left) に統一（.frag は uv*res-0.5 で復元）
-// した結果、CPU↔GLSL が等価になった。
+// した結果、CPU↔GLSL が高精度で一致するようになった（PSNR ベースで検証）。
 // ---------------------------------------------------------------------------
 
 /// cataract.frag の gridNoise を Rust で再現する（CPU `grid_hash` と bit 一致）。

--- a/docs/adr/matrix-provenance.md
+++ b/docs/adr/matrix-provenance.md
@@ -8,9 +8,11 @@ change a matrix can be audited — and so a downstream consumer can trace a numb
 back to its origin.
 
 Read this alongside [ADR-0001](0001-linear-srgb-machado-matrices.md) (why the
-matrices are applied directly in linear sRGB) and
+matrices are applied directly in linear sRGB),
 [ADR-0004](0004-achromatopsia-bt709-photopic.md) (the achromatopsia luminance
-path).
+path), and [ADR-0005](0005-phased-scope-phase1-four-types.md) (why
+tetrachromacy sits outside the colorimetrically-verifiable Phase 1 scope —
+relevant background for §3 below).
 
 ## Scope
 
@@ -20,6 +22,7 @@ path).
 | `DEUTERANOPIA` | 3×3 CVD matrix, severity = 1.0 | Machado 2009 |
 | `TRITANOPIA` | 3×3 CVD matrix, severity = 1.0 | Machado 2009 |
 | `LUMA_R` / `LUMA_G` / `LUMA_B` | photopic luminance weights | ITU-R BT.709 / sRGB (CIE Y) |
+| `HPE_LMS_HEURISTIC` | 3×3 heuristic matrix, linear RGB → pseudo-LMS (only rows 0–1 used) | Hunt-Pointer-Estévez XYZ→LMS (D65) — **not** Machado 2009; see §3 |
 
 ## 1. The dichromacy matrices (Machado 2009)
 
@@ -72,7 +75,7 @@ These are the exact values currently in `crates/core/src/vision/color.rs`:
 
 > The crate stores these as `f32`; the literals above are reproduced exactly as
 > written in the source const (and re-typed independently in the test — see
-> §3). Row order is `[R_out; G_out; B_out]`, column order is `[R_in, G_in,
+> §4). Row order is `[R_out; G_out; B_out]`, column order is `[R_in, G_in,
 > B_in]`, i.e. `out = M · in` per pixel in linear sRGB.
 
 ### How extracted
@@ -123,7 +126,64 @@ of ADR-0004.
 Standard published constants, copied verbatim from the BT.709 / sRGB
 specification.
 
-## 3. How these values are verified (pinning)
+## 3. Heuristic matrices (visualization-only, not colorimetric)
+
+Not every numeric matrix in the crate is a citable, source-anchored
+scientific instrument the way §1/§2 are. This section documents such
+matrices honestly: what the numbers actually are, where they came from, and
+that **no colorimetric fidelity is claimed** for them.
+
+### `HPE_LMS_HEURISTIC` (tetrachromacy, `crates/core/src/vision/color.rs`)
+
+**What it is.** The numeric values
+
+```
+[ 0.4002,  0.7076, -0.0808 ]
+[-0.2263,  1.1653,  0.0457 ]
+[ 0.0000,  0.0000,  0.9182 ]
+```
+
+are the **Hunt-Pointer-Estévez (HPE) CIE XYZ→LMS transform, D65
+white-point-normalized**. This matrix does **not** appear in Machado,
+Oliveira & Fernandes (2009) Table 1 — that table publishes only the three
+severity-1.0 dichromacy matrices listed in §1. An earlier revision of this
+codebase's comments incorrectly attributed this matrix to "Machado 2009,
+Equation 1 / Table 1"; that attribution was wrong and has been corrected
+(#170).
+
+**Why it's a heuristic, not a colorimetric LMS conversion.** `tetrachromacy`
+applies this matrix directly to **linear RGB**, with no sRGB→CIE XYZ step in
+between. A colorimetrically correct LMS conversion requires
+`linear RGB → CIE XYZ → LMS`; skipping the XYZ step means the resulting "L"
+and "M" values are not true cone tristimulus values — they are a fast,
+plausible-looking proxy used only to locate pixels where the red and green
+channels are hard to tell apart (a stand-in for a metameric-pair detector).
+Only rows 0–1 (L, M) are used by the filter; row 2 (S) is present in the
+matrix literal but unused.
+
+**What it's for.** `tetrachromacy` is a **visualization** of "what a
+four-cone observer might perceive differently," not a source-anchored
+simulation — see [ADR-0005](0005-phased-scope-phase1-four-types.md), which
+explicitly scopes tetrachromacy out of the first (colorimetrically
+verifiable) phase for exactly this reason. This spec does not claim, and the
+filter does not need, colorimetric fidelity from this matrix; it only needs
+a repeatable split between "similar red/green" and "distinguishable
+red/green" pixels.
+
+**Where it's duplicated.** The same six non-zero coefficients are hardcoded
+directly (not read from a named constant, since GLSL has no cross-file
+const import) in `crates/core/src/shaders/tetrachromacy.frag`, for the GPU
+path. Both copies carry the corrected provenance comment as of #170; the
+numeric values themselves are unchanged.
+
+**Verification coverage.** Unlike §1/§2, this matrix is **not** pinned by the
+independent-literal known-answer test described in §4 — `color_kat.rs` covers
+only `PROTANOPIA` / `DEUTERANOPIA` / `TRITANOPIA` / `LUMA_R/G/B`.
+`HPE_LMS_HEURISTIC` is instead covered by the CPU↔GLSL cross-check
+(`shader_equiv_tetrachromacy_*` in `crates/core/tests/shader_equivalence.rs`),
+which pins CPU/GPU agreement but not agreement against an external source.
+
+## 4. How these values are verified (pinning)
 
 The constants above are pinned against the source by a known-answer test (KAT),
 introduced in **#156**: `crates/core/tests/color_kat.rs`.
@@ -151,7 +211,7 @@ inputs surface coefficient changes of roughly `0.001–0.004`). Sub-`u8`
 floating-point drift that leaves every rounded channel unchanged is **out of
 scope by design** — the intrinsic limit of an 8-bit-output check.
 
-## 4. Procedure for changing a matrix (auditable improvement path)
+## 5. Procedure for changing a matrix (auditable improvement path)
 
 A future proposal to change any value in this spec **must**:
 
@@ -171,10 +231,13 @@ that keeps this spec, the code, and the tests in agreement.
 ## References
 
 - `crates/core/src/vision/color.rs` — `PROTANOPIA` / `DEUTERANOPIA` / `TRITANOPIA` /
-  `LUMA_R/G/B` consts and their derivation comments.
+  `LUMA_R/G/B` / `HPE_LMS_HEURISTIC` consts and their derivation comments.
+- `crates/core/src/shaders/tetrachromacy.frag` — GPU-side hardcoded copy of the
+  `HPE_LMS_HEURISTIC` coefficients (§3).
 - `crates/core/tests/color_kat.rs` — `SRC_*`, `BT709`, reference pipeline,
   `golden_*`, and `cross_check_*` tests.
 - `docs/overview.md` — "Color vision algorithm (Phase 1, #2)" and "GLSL ES 3.00
   shader source API" (the source-consistency vs self-consistency distinction).
 - [ADR-0001](0001-linear-srgb-machado-matrices.md),
-  [ADR-0004](0004-achromatopsia-bt709-photopic.md).
+  [ADR-0004](0004-achromatopsia-bt709-photopic.md),
+  [ADR-0005](0005-phased-scope-phase1-four-types.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -228,8 +228,10 @@ matrices and luminance coefficients is in
 
 ## Tetrachromacy algorithm (Phase 1+, #3)
 
-`tetrachromacy` approximates what a tetrachromat might perceive by
-exaggerating color differences that trichromats cannot distinguish.
+`tetrachromacy` approximates what a tetrachromat might perceive by detecting
+**metameric-pair candidates** — pixels whose red and green channels a
+trichromat would tend to confuse — and exaggerating their chroma, plus a
+baseline red–green opponent exaggeration applied everywhere else.
 
 ### Fundamental limitation
 
@@ -237,26 +239,40 @@ RGB cameras and displays capture only 3 channels; the fourth spectral
 dimension that a tetrachromat's extra cone type would sense is not
 recorded. A physically exact simulation is **impossible from RGB input**.
 The filter instead renders a visualization: "if a difference existed here,
-it might look like this."
+it might look like this." **No colorimetric fidelity is claimed** for any
+step of this algorithm, including the LMS-like values in step 2 below — see
+the "Heuristic matrices" section of
+[`adr/matrix-provenance.md`](adr/matrix-provenance.md).
 
 ### Algorithm
 
 1. Decode each pixel to **linear sRGB** (gamma removal).
-2. Compute **opponent channels**:
-   - `rg = R − G` (red–green axis; most relevant to the tetrachromat's
-     extra L/M cone overlap near 560 nm)
-   - `yb = 0.5×(R+G) − B` (yellow–blue axis)
-3. Exaggerate each axis scaled by `strength`:
+2. Compute a **pseudo-LMS** `L`/`M` pair: apply the `HPE_LMS_HEURISTIC`
+   matrix (the Hunt-Pointer-Estévez XYZ→LMS transform, D65-normalized) directly
+   to the linear RGB triple, with **no sRGB→CIE XYZ step** in between. This is
+   a fast heuristic proxy, not a colorimetric LMS conversion — the resulting
+   `L`/`M` are not true cone tristimulus values, only a repeatable stand-in
+   used to locate likely metameric pairs (the matrix's third, `S`, row is
+   present but unused).
+3. Compute the metameric indicator `delta = M − L`.
+4. **Baseline branch** (always computed first): red–green opponent
+   exaggeration `rg = R − G`, scaled by `strength`:
    - `R_out = R + strength × rg × k_rg` (`k_rg = 0.5`)
    - `G_out = G − strength × rg × k_rg`
-   - `B_out = B + strength × yb × k_yb` (`k_yb = 0.25`, subtler)
-4. Clamp each channel to `0.0..=1.0`.
-5. Re-encode to sRGB (gamma application).
-6. Alpha is preserved.
+   - `B_out = B` (unchanged)
+5. **Metameric-pair override**: if `|delta| < 0.05` (a metameric-pair
+   candidate region), replace the baseline result with a Cb/Cr chroma
+   exaggeration around the pixel's BT.709 luma `Y`:
+   - `Cb = B − Y`, `Cr = R − Y`, `scale = strength × 2.0`
+   - `R_out = Y + Cr × scale`, `G_out = Y`, `B_out = Y + Cb × scale`
+6. Clamp each channel to `0.0..=1.0`.
+7. Re-encode to sRGB (gamma application).
+8. Alpha is preserved.
 
-**Uniform colours** (R = G = B) produce `rg = yb = 0` and are therefore
-unchanged regardless of `strength`. The effect is visible only where
-hue differences already exist in the source image.
+**Uniform colours** (R = G = B) produce `rg = Cb = Cr = 0`, so both branches
+reduce to the identity — the pixel is unchanged regardless of `strength` or
+which branch fires. The effect is visible only where hue differences already
+exist in the source image.
 
 
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -255,8 +255,10 @@ the "Heuristic matrices" section of
    used to locate likely metameric pairs (the matrix's third, `S`, row is
    present but unused).
 3. Compute the metameric indicator `delta = M − L`.
-4. **Baseline branch** (always computed first): red–green opponent
-   exaggeration `rg = R − G`, scaled by `strength`:
+4. **Baseline branch** (always computed first *in the CPU reference
+   implementation*; the GLSL shader instead takes an equivalent if/else,
+   computing only one branch per pixel): red–green opponent exaggeration
+   `rg = R − G`, scaled by `strength`:
    - `R_out = R + strength × rg × k_rg` (`k_rg = 0.5`)
    - `G_out = G − strength × rg × k_rg`
    - `B_out = B` (unchanged)


### PR DESCRIPTION
## 関連 Issue
closes #170

## 変更内容
- myopia docstring の「5%」を実定数 2.3% (`MYOPIA_MAX_RADIUS_RATIO=0.023`) に是正
- `SRGB_TO_LMS` → `HPE_LMS_HEURISTIC` にリネームし、出典注記を事実（Hunt-Pointer-Estévez XYZ→LMS D65 を linear RGB に直接流用したヒューリスティック）に是正。matrix-provenance.md に Heuristic matrices 節を新設し scope 表と整合
- cataract コメントを「VIP-Sim 二段モデルの再解釈」に是正し、原典（brightness ×(1−s)・pivot=ContrastCoeff）との差分を明記
- tetrachromacy.frag 冒頭コメントの「簡略版」記述を実装（CPU と同じメタメリック分岐あり）に同期
- cataract の「CPU↔GLSL bit 一致」表現を「整数ハッシュ系列が bit 一致（最終画素は pow() の last-ULP 差あり得る）」に精緻化（light.rs / shader_equivalence.rs ヘッダ）
- docs/overview.md の Tetrachromacy 節を現行実装に同期

## 検証
- 挙動・定数値・テストアサーション変更ゼロ。cargo test 489 passed / clippy -D warnings clean / fmt clean